### PR TITLE
fix: address `io/ioutil` depreciation and `d.Set` errcheck

### DIFF
--- a/internal/provider/data_source_curl_request.go
+++ b/internal/provider/data_source_curl_request.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -102,14 +102,16 @@ func dataSourceCurlRequestRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	defer resp.Body.Close()
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return diag.FromErr(readErr)
 	}
 
 	respBody.responseBody = string(body)
 
-	d.Set("response", string(body))
+	if err := d.Set("response", string(body)); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }

--- a/internal/provider/resource_curl.go
+++ b/internal/provider/resource_curl.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"io/ioutil"
-	"net/http"
 )
 
 func resourceCurl() *schema.Resource {
@@ -175,7 +176,7 @@ func resourceCurlCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	defer resp.Body.Close()
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return diag.FromErr(readErr)
 	}
@@ -194,7 +195,9 @@ func resourceCurlCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	respBody.responseBody = string(body)
 
-	d.Set("response", string(body))
+	if err := d.Set("response", string(body)); err != nil {
+		return diag.FromErr(err)
+	}
 
 	tflog.Trace(ctx, "created a resource")
 
@@ -274,7 +277,7 @@ func resourceCurlDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	defer resp.Body.Close()
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return diag.FromErr(readErr)
 	}


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Addrresses the following issues that would be seen by `golangci-lint`:

- `io/ioutil` is deprecated as of Go 1.16. Converts to the use of the `io` package and update `ioutil.ReadAll...` to `io.ReadAll...`


   Reference: https://github.com/golang/go/issues/40025

- Addresses the error return value of `d.Set` is not being checked.

Built and used a local copy of the provider without any observed errors against public endpoint with success.

Signed-off-by: Ryan Johnson <ryan@tenthirtyam.org>

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)? 
  
  For example: 
  - Resolves #1234
-->

Resolves #18

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
