### PR TITLE
Fix retry logic as retries would always fail with Bad Request

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 name = terracurl
 organization = devops-rob
-version = 1.0.0
+version = 1.0.1
 arch = darwin_amd64
 #arch = linux_amd64
 


### PR DESCRIPTION
This PR fixes issue #37 by ensuring that the http.Request is correctly recreated for every request, ensuring the request body is available for retries.

Also bumped one patch version and added some additional logging and tests.