### PR TITLE
fix: skip_tls_verify working

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,12 +5,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const TerraformProviderProductUserAgent = "terraform-provider-terracurl"
@@ -36,9 +37,13 @@ func (tc *TLSClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func NewTLSClient(certFile, keyFile, caCert, caDir string, insecureSkipVerify bool) (HTTPClient, error) {
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, err
+	var cert tls.Certificate
+	if certFile != "" {
+		c, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, err
+		}
+		cert = c
 	}
 
 	var rootCAs *x509.CertPool
@@ -86,10 +91,6 @@ func NewTLSClient(certFile, keyFile, caCert, caDir string, insecureSkipVerify bo
 }
 
 func setClient(certFile, keyFile, caCert, caDir string, insecureSkipVerify bool) error {
-	if certFile == "" {
-		return nil
-	}
-
 	tlsClient, err := NewTLSClient(certFile, keyFile, caCert, caDir, insecureSkipVerify)
 	if err != nil {
 		return err


### PR DESCRIPTION
Resolve #41

* Changed insecureSkipVerify to work even if certFile is empty
* Change import order by goimports

`skip_tls_verify` was disabled when `cert_file` was empty.
If `skip_tls_verify` is specified as true, `NewTLSClient` must be called even if the `cert_file` is empty, since the `cert_file` is not required.