### PR TITLE
Adds destroy_skip to avoid hitting example.com in the destroy phase

### DIFF
--- a/docs/resources/request.md
+++ b/docs/resources/request.md
@@ -102,6 +102,7 @@ output "response" {
 - `destroy_request_body` (String) A request body to attach to the API call
 - `destroy_response_codes` (List of String) A list of expected response codes for destroy operations
 - `destroy_retry_interval` (Number) Interval between each attempt
+- `destroy_skip` (Boolean) Set this to true to skip issuing a request when the resource is being destroyed.
 - `destroy_skip_tls_verify` (Boolean) Set this to true to disable verification of the Vault server's TLS certificate
 - `destroy_timeout` (Number) Time in seconds before each request times out. Defaults to 10
 - `destroy_url` (String) Api endpoint to call

--- a/internal/provider/resource_curl.go
+++ b/internal/provider/resource_curl.go
@@ -144,6 +144,11 @@ func resourceCurl() *schema.Resource {
 				Computed:    true,
 				Description: "Response status code received from request",
 			},
+			"destroy_skip": {
+				Description: "Set this to true to skip issuing a request when the resource is being destroyed.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 			"destroy_url": {
 				Description: "Api endpoint to call",
 				Type:        schema.TypeString,
@@ -487,6 +492,11 @@ func resourceCurlUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 func resourceCurlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	if skipDestroyRequest, _ := d.Get("destroy_skip").(bool); skipDestroyRequest {
+		return diags
+	}
+
 	id := d.Get("name").(string)
 	d.SetId(id)
 


### PR DESCRIPTION
We noticed recently In testing modules using the terracurl resource that:

1. When no destroy information is provided the default behavior for this module is to issue a DELETE request to example.com expecting a 405
2. Example.com appears to no longer process incoming DELETE request, instead issuing a 501

```shell
curl -v -X DELETE http://example.com
* Host example.com:80 was resolved.
* IPv6: (none)
* IPv4: 23.192.228.84, 23.192.228.80, 23.215.0.138, 96.7.128.175, 96.7.128.198, 23.215.0.136
*   Trying 23.192.228.84:80...
* Connected to example.com (23.192.228.84) port 80
> DELETE / HTTP/1.1
> Host: example.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 501 Not Implemented
< Mime-Version: 1.0
< Content-Type: text/html
< Content-Length: 337
< Cache-Control: max-age=0
< Date: Thu, 16 Jan 2025 14:38:42 GMT
< Connection: close
<
<HTML><HEAD>
<TITLE>Unsupported Request</TITLE>
</HEAD><BODY>
<H1>Unsupported Request</H1>
DELETE to http&#58;&#47;&#47;example&#46;com&#47; not supported.<P>
Reference&#32;&#35;8&#46;64a33017&#46;1737038322&#46;ad71443
<P>https&#58;&#47;&#47;errors&#46;edgesuite&#46;net&#47;8&#46;64a33017&#46;1737038322&#46;ad71443</P>
</BODY></HTML>
* Closing connection
```

This has the potential to brick a number of real world use cases.  At a minimum the default expectation should be fixed in another change.  This pull requests aims to make the destroy phase entirely optional by skipping actually issuing any outbound requests when the resource is in the destroy phase, thus silently releasing the resource to destruction.