### PR TITLE
Adding ability to overwrite "host" header when submitting a request

### DIFF
--- a/internal/provider/curl_data_source.go
+++ b/internal/provider/curl_data_source.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"io"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 // Ensure the implementation satisfies the desired interfaces.
@@ -198,6 +200,11 @@ func (d *CurlDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	if !data.Headers.IsNull() && !data.Headers.IsUnknown() {
 		for k, v := range data.Headers.Elements() {
 			if strVal, ok := v.(types.String); ok {
+				lowerHeaderName := strings.ToLower(k)
+				if lowerHeaderName == "host" {
+					request.Host = strVal.ValueString()
+					continue
+				}
 				request.Header.Set(k, strVal.ValueString())
 			}
 		}

--- a/internal/provider/curl_ephemeral_resource.go
+++ b/internal/provider/curl_ephemeral_resource.go
@@ -5,6 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/ephemeralvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
@@ -12,10 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"io"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 var _ provider.ProviderWithEphemeralResources = (*TerraCurlProvider)(nil)
@@ -425,6 +427,11 @@ func (e *EphemeralCurlResource) Open(ctx context.Context, req ephemeral.OpenRequ
 	if !data.Headers.IsNull() && !data.Headers.IsUnknown() {
 		for k, v := range data.Headers.Elements() {
 			if strVal, ok := v.(types.String); ok {
+				lowerHeaderName := strings.ToLower(k)
+				if lowerHeaderName == "host" {
+					request.Host = strVal.ValueString()
+					continue
+				}
 				request.Header.Set(k, strVal.ValueString())
 			}
 		}

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"io"
-	"net/http"
-	"strconv"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -502,6 +504,11 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if !data.Headers.IsNull() && !data.Headers.IsUnknown() {
 		for k, v := range data.Headers.Elements() {
 			if strVal, ok := v.(types.String); ok {
+				lowerHeaderName := strings.ToLower(k)
+				if lowerHeaderName == "host" {
+					request.Host = strVal.ValueString()
+					continue
+				}
 				request.Header.Set(k, strVal.ValueString())
 			}
 		}


### PR DESCRIPTION
Currently if you configure the `headers` variable like so:

```
headers = {
    host = "example.com"
  }
```

The host header is ignored and instead the `url` attribute is used. This allows you to achieve the same functionality as:
```
curl -H "Host: example.com" http://localhost/
```

This fixes issue: https://github.com/devops-rob/terraform-provider-terracurl/issues/79