### PR TITLE
Fix Create() response sanitization bug and expired TLS test certs

### DIFF
--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -594,10 +594,25 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 		}
 	}
 
+	// Sanitize the response to normalize JSON and apply ignore_response_fields,
+	// matching the same transformation that Read() applies.
+	var ignoredFields []string
+	for _, v := range data.IgnoreResponseFields.Elements() {
+		if strVal, ok := v.(types.String); ok {
+			ignoredFields = append(ignoredFields, strVal.ValueString())
+		}
+	}
+
+	sanitizedResponse, err := sanitizeResponse(bodyString, ignoredFields)
+	if err != nil {
+		resp.Diagnostics.AddError("Sanitize Error", fmt.Sprintf("Failed to sanitize response: %s", err))
+		return
+	}
+
 	data.DriftMarker = types.StringValue("initial")
 	data.DestroyRequestUrlString = types.StringValue(data.DestroyUrl.ValueString())
 	data.RequestUrlString = types.StringValue(request.URL.String())
-	data.Response = types.StringValue(bodyString)
+	data.Response = types.StringValue(sanitizedResponse)
 	data.StatusCode = types.StringValue(strconv.Itoa(statusCode))
 	diags := resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -5,6 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,10 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"io"
-	"net/http"
-	"strconv"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -32,8 +33,10 @@ const (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
-var _ resource.Resource = &CurlResource{}
-var _ resource.ResourceWithImportState = &CurlResource{}
+var (
+	_ resource.Resource                = &CurlResource{}
+	_ resource.ResourceWithImportState = &CurlResource{}
+)
 
 func NewCurlResource() resource.Resource {
 	return &CurlResource{}
@@ -967,17 +970,17 @@ func (r *CurlResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 
 				// The main issue is that v0 used "destroy_parameters" but v1 uses "destroy_request_parameters"
 				// We need to handle this attribute rename during the upgrade
-				
+
 				var oldState CurlResourceModel
-				
+
 				// First, try the normal state extraction
 				diags := req.State.Get(ctx, &oldState)
-				
+
 				if diags.HasError() {
 					tflog.Info(ctx, "Direct state extraction failed, attempting to extract values from raw state", map[string]interface{}{
 						"errors": diags.Errors(),
 					})
-					
+
 					// Try to extract what we can from the raw state
 					if req.RawState != nil && len(req.RawState.JSON) > 0 {
 						// Parse the raw JSON state
@@ -989,34 +992,34 @@ func (r *CurlResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 							resp.Diagnostics.AddError("State Upgrade Error", fmt.Sprintf("Failed to parse raw state: %s", err))
 							return
 						}
-						
+
 						tflog.Debug(ctx, "Successfully parsed raw state, extracting values")
-						
+
 						// Extract core values from raw state
 						if id, ok := rawStateMap["id"].(string); ok && id != "" {
 							oldState.Id = types.StringValue(id)
 						} else {
 							oldState.Id = types.StringUnknown()
 						}
-						
+
 						if name, ok := rawStateMap["name"].(string); ok && name != "" {
 							oldState.Name = types.StringValue(name)
 						} else {
 							oldState.Name = types.StringUnknown()
 						}
-						
+
 						if url, ok := rawStateMap["url"].(string); ok && url != "" {
 							oldState.Url = types.StringValue(url)
 						} else {
 							oldState.Url = types.StringUnknown()
 						}
-						
+
 						if method, ok := rawStateMap["method"].(string); ok && method != "" {
 							oldState.Method = types.StringValue(method)
 						} else {
 							oldState.Method = types.StringUnknown()
 						}
-						
+
 						// Extract optional string fields
 						oldState.RequestBody = extractStringFromRaw(rawStateMap, "request_body")
 						oldState.CertFile = extractStringFromRaw(rawStateMap, "cert_file")
@@ -1026,11 +1029,11 @@ func (r *CurlResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 						oldState.DestroyUrl = extractStringFromRaw(rawStateMap, "destroy_url")
 						oldState.DestroyMethod = extractStringFromRaw(rawStateMap, "destroy_method")
 						oldState.DestroyRequestBody = extractStringFromRaw(rawStateMap, "destroy_request_body")
-						
+
 						// Extract boolean fields
 						oldState.SkipTlsVerify = extractBoolFromRaw(rawStateMap, "skip_tls_verify")
 						oldState.SkipDestroy = extractBoolFromRaw(rawStateMap, "skip_destroy")
-						
+
 						// Extract int64 fields
 						oldState.RetryInterval = extractInt64FromRaw(rawStateMap, "retry_interval")
 						oldState.MaxRetry = extractInt64FromRaw(rawStateMap, "max_retry")
@@ -1038,12 +1041,12 @@ func (r *CurlResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 						oldState.DestroyRetryInterval = extractInt64FromRaw(rawStateMap, "destroy_retry_interval")
 						oldState.DestroyMaxRetry = extractInt64FromRaw(rawStateMap, "destroy_max_retry")
 						oldState.DestroyTimeout = extractInt64FromRaw(rawStateMap, "destroy_timeout")
-						
+
 						// Extract map fields
 						oldState.Headers = extractMapFromRaw(rawStateMap, "headers")
 						oldState.RequestParameters = extractMapFromRaw(rawStateMap, "request_parameters")
 						oldState.DestroyHeaders = extractMapFromRaw(rawStateMap, "destroy_headers")
-						
+
 						// Handle the key attribute rename: destroy_parameters -> destroy_request_parameters
 						if destroyParams := extractMapFromRaw(rawStateMap, "destroy_parameters"); !destroyParams.IsNull() {
 							oldState.DestroyRequestParameters = destroyParams
@@ -1051,25 +1054,25 @@ func (r *CurlResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 						} else {
 							oldState.DestroyRequestParameters = extractMapFromRaw(rawStateMap, "destroy_request_parameters")
 						}
-						
+
 						// Extract list fields
 						oldState.ResponseCodes = extractListFromRaw(rawStateMap, "response_codes")
 						oldState.DestroyResponseCodes = extractListFromRaw(rawStateMap, "destroy_response_codes")
 						oldState.IgnoreResponseFields = extractListFromRaw(rawStateMap, "ignore_response_fields")
-						
+
 						// Set remaining computed/null fields
 						oldState.RequestUrlString = types.StringNull()
 						oldState.Response = types.StringNull()
 						oldState.StatusCode = types.StringNull()
 						oldState.DestroyRequestUrlString = types.StringNull()
 						oldState.DriftMarker = types.StringNull()
-						
+
 					} else {
 						tflog.Error(ctx, "No raw state available for manual extraction")
 						resp.Diagnostics.AddError("State Upgrade Error", "No raw state available for manual extraction")
 						return
 					}
-					
+
 					// Clear the extraction errors since we handled them manually
 					resp.Diagnostics = diag.Diagnostics{}
 				}
@@ -1091,7 +1094,7 @@ func (r *CurlResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 				// Set the upgraded state
 				diags = resp.State.Set(ctx, oldState)
 				resp.Diagnostics.Append(diags...)
-				
+
 				if resp.Diagnostics.HasError() {
 					tflog.Error(ctx, "Failed to set upgraded state", map[string]interface{}{
 						"errors": resp.Diagnostics.Errors(),

--- a/internal/provider/curl_resource_test.go
+++ b/internal/provider/curl_resource_test.go
@@ -644,7 +644,7 @@ func TestAccCurlResourceWithTLS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccresourceCurlTls("tls_test", server.URL, certFile, certFile, keyFile, readServer.URL, readCertFile, readCertFile, readKeyFile, destroyServer.URL, destroyCertFile, destroyCertFile, destroyKeyFile),
-				Check:  resource.TestCheckResourceAttr("terracurl_request.tls_test", "response", `{"message": "TLS test successful"}`),
+				Check:  resource.TestCheckResourceAttr("terracurl_request.tls_test", "response", `{"message":"TLS test successful"}`),
 			},
 		},
 	})
@@ -760,10 +760,108 @@ func TestAccCurlResourceWithTLSSkipVerify(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccresourceCurlTlsSkipVerify("tls_test", server.URL, certFile, keyFile, readServer.URL, readCertFile, readKeyFile, destroyServer.URL, destroyCertFile, destroyKeyFile),
-				Check:  resource.TestCheckResourceAttr("terracurl_request.tls_test", "response", `{"message": "TLS test successful"}`),
+				Check:  resource.TestCheckResourceAttr("terracurl_request.tls_test", "response", `{"message":"TLS test successful"}`),
 			},
 		},
 	})
+}
+
+// TestAccresourceCurlCreateSanitizesResponse verifies that Create() normalizes
+// JSON responses the same way Read() does (via sanitizeResponse). Without this,
+// the response field differs between initial create and subsequent state refresh,
+// causing false drift detection.
+func TestAccresourceCurlCreateSanitizesResponse(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// Return JSON with keys in non-alphabetical order and extra whitespace.
+	// sanitizeResponse() normalizes this via JSON unmarshal/marshal (sorted keys, compact).
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/create",
+		httpmock.NewStringResponder(200, `{"zebra": "last", "alpha": "first"}`),
+	)
+
+	// After JSON round-trip through sanitizeResponse, keys are sorted alphabetically
+	// and formatting is compact.
+	expectedResponse := `{"alpha":"first","zebra":"last"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceCurlCreateSanitize(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terracurl_request.sanitize_test", "response", expectedResponse),
+				),
+			},
+		},
+	})
+}
+
+func testAccresourceCurlCreateSanitize() string {
+	return `
+resource "terracurl_request" "sanitize_test" {
+  name           = "sanitize-test"
+  url            = "https://example.com/create"
+  method         = "POST"
+  request_body   = "{}"
+  response_codes = ["200"]
+  skip_destroy   = true
+}
+`
+}
+
+// TestAccresourceCurlCreateIgnoresResponseFields verifies that Create() applies
+// ignore_response_fields filtering, matching Read() behavior.
+func TestAccresourceCurlCreateIgnoresResponseFields(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/create-ignore",
+		httpmock.NewStringResponder(200, `{"name":"keep","timestamp":"2026-01-01T00:00:00Z","request_id":"abc123"}`),
+	)
+
+	// After sanitization with ignore_response_fields = ["timestamp", "request_id"],
+	// only "name" should remain.
+	expectedResponse := `{"name":"keep"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceCurlCreateIgnoreFields(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terracurl_request.ignore_test", "response", expectedResponse),
+				),
+			},
+		},
+	})
+}
+
+func testAccresourceCurlCreateIgnoreFields() string {
+	return `
+resource "terracurl_request" "ignore_test" {
+  name           = "ignore-fields-test"
+  url            = "https://example.com/create-ignore"
+  method         = "POST"
+  request_body   = "{}"
+  response_codes = ["200"]
+  skip_destroy   = true
+
+  ignore_response_fields = ["timestamp", "request_id"]
+}
+`
 }
 
 func testMockEndpointCount(endpoint string, expected int) resource.TestCheckFunc {

--- a/internal/provider/curl_resource_test.go
+++ b/internal/provider/curl_resource_test.go
@@ -3,6 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	resource2 "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -13,10 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jarcoal/httpmock"
-	"net/http"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestAccresourceCurl(t *testing.T) {
@@ -59,12 +60,11 @@ func TestAccresourceCurl(t *testing.T) {
 					resource.TestCheckResourceAttr("terracurl_request.basic", "destroy_headers.Content-Type", "application/json"),
 					resource.TestCheckResourceAttr("terracurl_request.basic", "destroy_request_body", RequestBody+"\n"),
 
-					//resource.TestCheckResourceAttr("terracurl_request.basic", "destroy_request_url_string", "https://example.com/destroy?id=12345&name=devopsrob"),
+					// resource.TestCheckResourceAttr("terracurl_request.basic", "destroy_request_url_string", "https://example.com/destroy?id=12345&name=devopsrob"),
 				),
 			},
 		},
 	})
-
 }
 
 func testAccresourceCurl(name string, requestBody string) string {
@@ -142,7 +142,6 @@ func TestAccresourceCurlDestroy(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccresourceCurlDestroy(name string, requestBody string) string {
@@ -221,7 +220,6 @@ func TestAccresourceCurlSkipDestroy(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccresourceCurlSkipDestroy(name string, requestBody string) string {
@@ -361,7 +359,6 @@ EOF
 
 }
 `, body)
-
 }
 
 func TestAccresourceCurlSkipRead(t *testing.T) {
@@ -393,7 +390,6 @@ func TestAccresourceCurlSkipRead(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccresourceCurlSkipRead(name string, body string) string {
@@ -423,7 +419,6 @@ EOF
 
 }
 `, name, body)
-
 }
 
 func TestAccresourceCurlSkipReadNoReadFields(t *testing.T) {
@@ -500,7 +495,6 @@ func TestAccresourceCurlRead(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccresourceCurlRead(name string, body string) string {
@@ -530,7 +524,6 @@ EOF
 
 }
 `, name, body)
-
 }
 
 func testAccresourceCurlTls(name, url, caCertFile, certFile, keyFile, readUrl, readCaCertFile, readCertFile, readKeyFile, destroyUrl, destroyCaCertFile, destroyCertFile, destroyKeyFile string) string {
@@ -575,7 +568,6 @@ resource "terracurl_request" "tls_test" {
 
 }
 `, name, url, caCertFile, certFile, keyFile, readUrl, readCaCertFile, readCertFile, readKeyFile, destroyUrl, destroyCaCertFile, destroyCertFile, destroyKeyFile)
-
 }
 
 func TestAccCurlResourceWithTLS(t *testing.T) {
@@ -598,7 +590,7 @@ func TestAccCurlResourceWithTLS(t *testing.T) {
 		t.Fatalf("failed to create TLS test server for Destroy operation: %v. Cert file: %s", err, certFile)
 	}
 
-	//fmt.Printf("CertFile: %s, KeyFile: %s\n", certFile, keyFile)
+	// fmt.Printf("CertFile: %s, KeyFile: %s\n", certFile, keyFile)
 	defer server.Close()
 	defer readServer.Close()
 	defer destroyServer.Close()
@@ -692,7 +684,6 @@ resource "terracurl_request" "tls_test" {
 
 }
 `, name, url, certFile, keyFile, readUrl, readCertFile, readKeyFile, destroyUrl, destroyCertFile, destroyKeyFile)
-
 }
 
 func TestAccCurlResourceWithTLSSkipVerify(t *testing.T) {
@@ -1239,7 +1230,7 @@ func TestCurlResource_StateUpgrade_EmptyDestroyParameters(t *testing.T) {
 		JSON: []byte(rawStateJSON),
 	}
 
-	// Use the actual resource schema for consistency  
+	// Use the actual resource schema for consistency
 	rUpgrade2 := &CurlResource{}
 	schemaResp2 := &resource2.SchemaResponse{}
 	rUpgrade2.Schema(ctx, resource2.SchemaRequest{}, schemaResp2)
@@ -1252,7 +1243,7 @@ func TestCurlResource_StateUpgrade_EmptyDestroyParameters(t *testing.T) {
 	}
 
 	req := resource2.UpgradeStateRequest{
-		State: &tfsdk.State{Schema: emptySchema2},
+		State:    &tfsdk.State{Schema: emptySchema2},
 		RawState: rawState,
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -5,20 +5,28 @@ package provider
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
-	"encoding/hex"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
 	"log"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
 )
 
 // testAccProtoV6ProviderFactories are used to instantiate a provider during
@@ -34,67 +42,74 @@ var testAccProtoV6ProviderFactoriesWithEcho = map[string]func() (tfprotov6.Provi
 	"echo":      echoprovider.NewProviderServer(),
 }
 
-const localCert = `-----BEGIN CERTIFICATE-----
-MIICnDCCAkOgAwIBAgIRAJ7vRKfNUfgTzPf3A2usN5MwCgYIKoZIzj0EAwIwgbkx
-CzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNj
-bzEaMBgGA1UECRMRMTAxIFNlY29uZCBTdHJlZXQxDjAMBgNVBBETBTk0MTA1MRcw
-FQYDVQQKEw5IYXNoaUNvcnAgSW5jLjFAMD4GA1UEAxM3Q29uc3VsIEFnZW50IENB
-IDE3OTE0MzkwMDM4OTUwMjI2MjM2Njc1OTk3NzcwNTA5NjcxNjY5MzAeFw0yNTAy
-MjcxMzMxMDVaFw0yNjAyMjcxMzMxMDVaMBwxGjAYBgNVBAMTEXNlcnZlci5kYzEu
-Y29uc3VsMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjLj2Ay/hhLhJ1cC5Rp7/
-bkucDS+MrS8Te7HpXmQJAQt4DsMWbP9KJ9dc0LcE8rTwitkoLiTtjMl/y9J+I6jq
-H6OBxzCBxDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG
-AQUFBwMCMAwGA1UdEwEB/wQCMAAwKQYDVR0OBCIEIC31ZCjRSd188aHLNsUi6z25
-Dm0CsyHqBhCZ/1Xak9+RMCsGA1UdIwQkMCKAIKEBxmHeTfADtdpbF1Sww30JXIln
-rYqEyg+0PDbZW6yXMC0GA1UdEQQmMCSCEXNlcnZlci5kYzEuY29uc3Vsgglsb2Nh
-bGhvc3SHBH8AAAEwCgYIKoZIzj0EAwIDRwAwRAIgI3d9t7SOR9RaTrnFWGh+igXE
-4bZYvsUcWL2V9mA5T3MCIFH7XfGUEwuviYHt6Py1X9yaI5lcRxjgSOkFMMIsoY01
------END CERTIFICATE-----`
+// generateSelfSignedCert creates a fresh self-signed ECDSA certificate and key
+// valid for 1 hour, with SANs for localhost and 127.0.0.1. Returns PEM-encoded
+// cert and key bytes.
+func generateSelfSignedCert() ([]byte, []byte, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
 
-// Mock private key for TLS server.
-const localKey = `-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIHa08Nf/lf7KXSMcRwnhNOI5rpJsykbo4ZGImsZndeHYoAoGCCqGSM49
-AwEHoUQDQgAEjLj2Ay/hhLhJ1cC5Rp7/bkucDS+MrS8Te7HpXmQJAQt4DsMWbP9K
-J9dc0LcE8rTwitkoLiTtjMl/y9J+I6jqHw==
------END EC PRIVATE KEY-----`
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "terracurl-test",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	keyDER, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM, nil
+}
 
 func createTLSServer() (*httptest.Server, string, string, error) {
 	log.Println("createTLSServer() called...")
 
+	certPEM, keyPEM, err := generateSelfSignedCert()
+	if err != nil {
+		return nil, "", "", fmt.Errorf("failed to generate self-signed cert: %w", err)
+	}
+
 	// Save cert & key to temp files.
-	certFile, err := saveTempFile([]byte(localCert))
+	certFile, err := saveTempFile(certPEM)
 	if err != nil {
 		log.Printf("Failed to create cert file: %v\n", err)
 		return nil, "", "", err
 	}
 
-	keyFile, err := saveTempFile([]byte(localKey))
+	keyFile, err := saveTempFile(keyPEM)
 	if err != nil {
 		log.Printf("Failed to create key file: %v\n", err)
 		return nil, "", "", err
 	}
 
-	// Read and print file contents.
-	certContent, err := os.ReadFile(certFile)
-	if err != nil {
-		log.Printf("Failed to read cert file: %v\n", err)
-		return nil, "", "", err
-	}
-
-	keyContent, err := os.ReadFile(keyFile)
-	if err != nil {
-		log.Printf("Failed to read key file: %v\n", err)
-		return nil, "", "", err
-	}
-
-	log.Printf("Cert file content:\n%s", string(certContent))
-	log.Printf("Key file content:\n%s", string(keyContent))
-
-	certHex := hex.EncodeToString(certContent)
-	keyHex := hex.EncodeToString(keyContent)
-
-	log.Printf("Cert file hex:\n%s", certHex)
-	log.Printf("Key file hex:\n%s", keyHex)
+	fmt.Printf("CertFile: %s, KeyFile: %s\n", certFile, keyFile)
 
 	// Load the TLS key pair.
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)


### PR DESCRIPTION
## Summary

- **Fix response sanitization bug in `Create()`**: `Create()` stored raw HTTP response bodies while `Read()` passed them through `sanitizeResponse()` (JSON normalization + `ignore_response_fields` filtering). This caused the `response` state field to differ between initial `terraform apply` and subsequent `terraform plan`, triggering false drift detection. `Create()` now applies the same sanitization as `Read()`.

- **Fix expired TLS test certificates**: Replace hardcoded PEM constants (expired 2026-02-27) with dynamic self-signed certificate generation at test runtime using Go's `crypto/x509` stdlib. Certificates are now generated fresh for each test run (valid 1 hour), eliminating future expiration failures.

- **Apply `go fmt` formatting** to touched files.

## Changes

| File | What changed |
|------|-------------|
| `internal/provider/curl_resource.go` | Add `sanitizeResponse()` call in `Create()` before storing response to state, applying JSON normalization and `ignore_response_fields` filtering to match `Read()` behavior |
| `internal/provider/provider_test.go` | Remove `localCert`/`localKey` constants; add `generateSelfSignedCert()` using ECDSA P-256; update `createTLSServer()` to use dynamic certs |
| `internal/provider/curl_resource_test.go` | Add `TestAccresourceCurlCreateSanitizesResponse` and `TestAccresourceCurlCreateIgnoresResponseFields`; update TLS test expectations to match normalized JSON format |

## Test plan

- [x] All 29 tests pass: `TF_ACC=1 go test ./internal/provider/... -v`
- [x] `go vet ./...` clean
- [x] `go fmt ./...` clean
- [x] Previously failing tests now pass: `TestAccCurlDataSourceTLS`, `TestAccCurlEmphemeralResourceWithTLS`, `TestAccCurlResourceWithTLS`
- [x] New tests written via Red/Green TDD: confirmed tests fail before fix, pass after

---

*This work was performed with the assistance of an AI coding agent ([Claude Code](https://claude.ai/claude-code)).*