### PR TITLE
Fix Host header override in request header maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.1
+
+BUG FIXES:
+
+- Fix Host header override when `Host` is set in request header maps (fixes #79). Based on #97 by @JoshBlades.
+
 ## 2.3.0
 
 FEATURES:

--- a/docs/data-sources/request.md
+++ b/docs/data-sources/request.md
@@ -27,7 +27,7 @@ TerraCurl request data source
 - `ca_cert_directory` (String) Path to a directory on local disk that contains one or more certificate files that will be used to validate the certificate presented by the server
 - `ca_cert_file` (String) Path to a file on local disk that will be used to validate the certificate presented by the server
 - `cert_file` (String) Path to a file on local disk that contains the PEM-encoded certificate to present to the server
-- `headers` (Map of String) Map of headers to attach to the API call
+- `headers` (Map of String) Map of headers to attach to the API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
 - `key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued
 - `max_retry` (Number) Maximum number of tries until it is marked as failed
 - `request_body` (String) A request body to attach to the API call

--- a/docs/ephemeral-resources/request.md
+++ b/docs/ephemeral-resources/request.md
@@ -30,7 +30,7 @@ TerraCurl request ephemeral resource
 - `close_ca_cert_directory` (String) Path to a directory on local disk that contains one or more certificate files that will be used to validate the certificate presented by the server
 - `close_ca_cert_file` (String) Path to a file on local disk that will be used to validate the certificate presented by the server
 - `close_cert_file` (String) Path to a file on local disk that contains the PEM-encoded certificate to present to the server
-- `close_headers` (Map of String) Map of headers to attach to the API call
+- `close_headers` (Map of String) Map of headers to attach to the API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
 - `close_key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued
 - `close_max_retry` (Number) Maximum number of tries until it is marked as failed
 - `close_method` (String) HTTP method to use in the API call
@@ -41,13 +41,13 @@ TerraCurl request ephemeral resource
 - `close_skip_tls_verify` (Boolean) Set this to true to disable verification of the server's TLS certificate
 - `close_timeout` (Number) Time in seconds before each request times out. Defaults to 10
 - `close_url` (String) Api endpoint to call
-- `headers` (Map of String) Map of headers to attach to the API call
+- `headers` (Map of String) Map of headers to attach to the API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
 - `key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued
 - `max_retry` (Number) Maximum number of tries until it is marked as failed
 - `renew_ca_cert_directory` (String) Path to a directory on local disk that contains one or more certificate files that will be used to validate the certificate presented by the server
 - `renew_ca_cert_file` (String) Path to a file on local disk that will be used to validate the certificate presented by the server
 - `renew_cert_file` (String) Path to a file on local disk that contains the PEM-encoded certificate to present to the server
-- `renew_headers` (Map of String) Map of headers to attach to the API call
+- `renew_headers` (Map of String) Map of headers to attach to the API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
 - `renew_interval` (Number) Interval in seconds to renew this resource.
 - `renew_key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued
 - `renew_max_retry` (Number) Maximum number of tries until it is marked as failed

--- a/docs/resources/request.md
+++ b/docs/resources/request.md
@@ -30,7 +30,7 @@ TerraCurl request resource
 - `destroy_ca_cert_directory` (String) Path to a directory on local disk that contains one or more certificate files that will be used to validate the certificate presented by the server for the destroy call
 - `destroy_ca_cert_file` (String) Path to a file on local disk that will be used to validate the certificate presented by the server for the destroy call
 - `destroy_cert_file` (String) Path to a file on local disk that contains the PEM-encoded certificate to present to the server for the destroy call
-- `destroy_headers` (Map of String) Map of headers to attach to the destroy API call
+- `destroy_headers` (Map of String) Map of headers to attach to the destroy API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
 - `destroy_key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued for the destroy call
 - `destroy_max_retry` (Number) Maximum number of tries until it is marked as failed for the destroy call
 - `destroy_method` (String) Destroy HTTP method to use in the API call
@@ -41,14 +41,14 @@ TerraCurl request resource
 - `destroy_skip_tls_verify` (Boolean) Set this to true to disable verification of the server's TLS certificate for the destroy call
 - `destroy_timeout` (Number) Time in seconds before each request times out for the destroy call. Defaults to 10
 - `destroy_url` (String) Destroy API endpoint to call
-- `headers` (Map of String) Map of headers to attach to the API call
+- `headers` (Map of String) Map of headers to attach to the API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
 - `ignore_response_fields` (List of String) List of JSON fields to ignore during drift detection.
 - `key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued
 - `max_retry` (Number) Maximum number of tries until it is marked as failed
 - `read_ca_cert_directory` (String) Path to a PEM-encoded CA certificate for the read request (TLS).
 - `read_ca_cert_file` (String) Path to a PEM-encoded CA certificate for the read request (TLS).
 - `read_cert_file` (String) Path to a PEM-encoded certificate for the read request (TLS).
-- `read_headers` (Map of String) Map of headers for the read request.
+- `read_headers` (Map of String) Map of headers for the read request. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
 - `read_key_file` (String) Path to a PEM-encoded private key for the read request (TLS).
 - `read_method` (String) HTTP method for reading resource state. Required if `skip_read` is false.
 - `read_parameters` (Map of String) Optional request parameters to add to the URL

--- a/examples/data-sources/host_header_example/data-source.tf
+++ b/examples/data-sources/host_header_example/data-source.tf
@@ -1,0 +1,14 @@
+# Override the HTTP Host header independently of the URL hostname.
+# Useful for CDN origin checks, virtual host routing, and end-to-end tests.
+
+data "terracurl_request" "virtual_host" {
+  name   = "virtual-host"
+  url    = "https://origin.example.com"
+  method = "GET"
+
+  headers = {
+    Host = "www.example.com"
+  }
+
+  response_codes = ["200"]
+}

--- a/internal/provider/curl_data_source.go
+++ b/internal/provider/curl_data_source.go
@@ -82,7 +82,7 @@ func (d *CurlDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			"headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of headers to attach to the API call",
+				MarkdownDescription: "Map of headers to attach to the API call." + hostHeaderMarkdownSuffix,
 			},
 			"request_parameters": schema.MapAttribute{
 				ElementType:         types.StringType,
@@ -210,13 +210,7 @@ func (d *CurlDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	// Add headers.
-	if !data.Headers.IsNull() && !data.Headers.IsUnknown() {
-		for k, v := range data.Headers.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				request.Header.Set(k, strVal.ValueString())
-			}
-		}
-	}
+	applyRequestHeaders(request, data.Headers)
 
 	// Add query parameters.
 	if !data.RequestParameters.IsNull() && !data.RequestParameters.IsUnknown() {

--- a/internal/provider/curl_ephemeral_resource.go
+++ b/internal/provider/curl_ephemeral_resource.go
@@ -131,7 +131,7 @@ func (e *EphemeralCurlResource) Schema(ctx context.Context, req ephemeral.Schema
 			"headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of headers to attach to the API call",
+				MarkdownDescription: "Map of headers to attach to the API call." + hostHeaderMarkdownSuffix,
 			},
 			"request_parameters": schema.MapAttribute{
 				ElementType:         types.StringType,
@@ -214,7 +214,7 @@ func (e *EphemeralCurlResource) Schema(ctx context.Context, req ephemeral.Schema
 			"renew_headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of headers to attach to the API call",
+				MarkdownDescription: "Map of headers to attach to the API call." + hostHeaderMarkdownSuffix,
 			},
 			"renew_request_parameters": schema.MapAttribute{
 				ElementType:         types.StringType,
@@ -288,7 +288,7 @@ func (e *EphemeralCurlResource) Schema(ctx context.Context, req ephemeral.Schema
 			"close_headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of headers to attach to the API call",
+				MarkdownDescription: "Map of headers to attach to the API call." + hostHeaderMarkdownSuffix,
 			},
 			"close_request_parameters": schema.MapAttribute{
 				ElementType:         types.StringType,
@@ -438,13 +438,7 @@ func (e *EphemeralCurlResource) Open(ctx context.Context, req ephemeral.OpenRequ
 	}
 
 	// Add headers.
-	if !data.Headers.IsNull() && !data.Headers.IsUnknown() {
-		for k, v := range data.Headers.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				request.Header.Set(k, strVal.ValueString())
-			}
-		}
-	}
+	applyRequestHeaders(request, data.Headers)
 
 	// Add query parameters.
 	if !data.RequestParameters.IsNull() && !data.RequestParameters.IsUnknown() {
@@ -1089,13 +1083,7 @@ func (e *EphemeralCurlResource) Renew(ctx context.Context, req ephemeral.RenewRe
 	}
 
 	// Add headers
-	if !privateData.RenewHeaders.IsNull() && !privateData.RenewHeaders.IsUnknown() {
-		for k, v := range privateData.RenewHeaders.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				request.Header.Set(k, strVal.ValueString())
-			}
-		}
-	}
+	applyRequestHeaders(request, privateData.RenewHeaders)
 
 	tflog.Debug(ctx, fmt.Sprintf("Parameters: %v\n", privateData.RenewRequestParameters.Elements()))
 
@@ -1445,14 +1433,10 @@ func (e *EphemeralCurlResource) Close(ctx context.Context, req ephemeral.CloseRe
 		return
 	}
 
-	if !privateData.CloseHeaders.IsNull() && !privateData.CloseHeaders.IsUnknown() {
-		for k, v := range privateData.CloseHeaders.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				request.Header.Set(k, strVal.ValueString())
-			}
-		}
-	} else {
+	if privateData.CloseHeaders.IsNull() || privateData.CloseHeaders.IsUnknown() {
 		tflog.Debug(ctx, "No CloseHeaders provided, proceeding without headers")
+	} else {
+		applyRequestHeaders(request, privateData.CloseHeaders)
 	}
 
 	// Add Query Parameters

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -142,7 +142,7 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of headers to attach to the API call",
+				MarkdownDescription: "Map of headers to attach to the API call." + hostHeaderMarkdownSuffix,
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.RequiresReplace(),
 				},
@@ -255,7 +255,7 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"destroy_headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of headers to attach to the destroy API call",
+				MarkdownDescription: "Map of headers to attach to the destroy API call." + hostHeaderMarkdownSuffix,
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.RequiresReplace(),
 				},
@@ -347,7 +347,7 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"read_headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of headers for the read request.",
+				MarkdownDescription: "Map of headers for the read request." + hostHeaderMarkdownSuffix,
 			},
 
 			"read_request_body": schema.StringAttribute{
@@ -510,13 +510,7 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Add headers
-	if !data.Headers.IsNull() && !data.Headers.IsUnknown() {
-		for k, v := range data.Headers.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				request.Header.Set(k, strVal.ValueString())
-			}
-		}
-	}
+	applyRequestHeaders(request, data.Headers)
 
 	// Add query parameters
 	if !data.RequestParameters.IsNull() && !data.RequestParameters.IsUnknown() {
@@ -661,13 +655,7 @@ func (r *CurlResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	// ======= Add Headers =======
-	if !data.ReadHeaders.IsNull() && !data.ReadHeaders.IsUnknown() {
-		for k, v := range data.ReadHeaders.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				request.Header.Set(k, strVal.ValueString())
-			}
-		}
-	}
+	applyRequestHeaders(request, data.ReadHeaders)
 
 	// ======= Add Query Parameters =======
 	if !data.ReadParameters.IsNull() && !data.ReadParameters.IsUnknown() {
@@ -815,13 +803,7 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	// Add Headers
-	if !data.DestroyHeaders.IsNull() && !data.DestroyHeaders.IsUnknown() {
-		for k, v := range data.DestroyHeaders.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				request.Header.Set(k, strVal.ValueString())
-			}
-		}
-	}
+	applyRequestHeaders(request, data.DestroyHeaders)
 
 	// Add Query Parameters
 	if !data.DestroyRequestParameters.IsNull() && !data.DestroyRequestParameters.IsUnknown() {

--- a/internal/provider/host_header_test.go
+++ b/internal/provider/host_header_test.go
@@ -1,0 +1,153 @@
+package provider
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestApplyRequestHeadersHostOverride(t *testing.T) {
+	tests := []struct {
+		name       string
+		headerKey  string
+		headerVal  string
+		wantHost   string
+		wantHeader string
+	}{
+		{name: "Host", headerKey: "Host", headerVal: "www.example.com", wantHost: "www.example.com"},
+		{name: "host", headerKey: "host", headerVal: "www.example.com", wantHost: "www.example.com"},
+		{name: "HOST", headerKey: "HOST", headerVal: "www.example.com", wantHost: "www.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080/path", nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			headers, diags := types.MapValueFrom(t.Context(), types.StringType, map[string]string{
+				tt.headerKey: tt.headerVal,
+			})
+			if diags.HasError() {
+				t.Fatalf("failed to build headers map: %v", diags)
+			}
+
+			applyRequestHeaders(req, headers)
+
+			if req.Host != tt.wantHost {
+				t.Fatalf("expected request.Host %q, got %q", tt.wantHost, req.Host)
+			}
+			if got := req.Header.Get("Host"); got != "" {
+				t.Fatalf("expected empty Host header map entry, got %q", got)
+			}
+		})
+	}
+}
+
+func TestApplyRequestHeadersNonHost(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	headers, diags := types.MapValueFrom(t.Context(), types.StringType, map[string]string{
+		"Authorization": "Bearer token",
+		"Content-Type":  "application/json",
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build headers map: %v", diags)
+	}
+
+	applyRequestHeaders(req, headers)
+
+	if req.Header.Get("Authorization") != "Bearer token" {
+		t.Fatalf("expected Authorization header to be set")
+	}
+	if req.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("expected Content-Type header to be set")
+	}
+	if req.Host != "example.com" {
+		t.Fatalf("expected default host from URL, got %q", req.Host)
+	}
+}
+
+func TestApplyRequestHeadersNullAndUnknown(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	applyRequestHeaders(req, types.MapNull(types.StringType))
+	applyRequestHeaders(req, types.MapUnknown(types.StringType))
+
+	if len(req.Header) != 0 {
+		t.Fatalf("expected no headers to be applied, got %v", req.Header)
+	}
+}
+
+func TestApplyRequestHeadersHostWithOtherHeaders(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	headers, diags := types.MapValueFrom(t.Context(), types.StringType, map[string]string{
+		"Host":          "www.example.com",
+		"Authorization": "Bearer token",
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build headers map: %v", diags)
+	}
+
+	applyRequestHeaders(req, headers)
+
+	if req.Host != "www.example.com" {
+		t.Fatalf("expected request.Host override, got %q", req.Host)
+	}
+	if req.Header.Get("Authorization") != "Bearer token" {
+		t.Fatalf("expected Authorization header to be set")
+	}
+}
+
+func TestApplyRequestHeadersSentOnWire(t *testing.T) {
+	var receivedHost string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	headers, diags := types.MapValueFrom(t.Context(), types.StringType, map[string]string{
+		"Host": "www.example.com",
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build headers map: %v", diags)
+	}
+
+	applyRequestHeaders(req, headers)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	}()
+	_, _ = io.ReadAll(resp.Body)
+
+	if receivedHost != "www.example.com" {
+		t.Fatalf("expected server to receive Host %q, got %q", "www.example.com", receivedHost)
+	}
+}

--- a/internal/provider/utilities.go
+++ b/internal/provider/utilities.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -214,4 +215,22 @@ func convertStringMapToTFValues(input map[string]string) map[string]attr.Value {
 
 func hasValue(s types.String) bool {
 	return !s.IsNull() && s.ValueString() != ""
+}
+
+const hostHeaderMarkdownSuffix = " Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname."
+
+func applyRequestHeaders(req *http.Request, headers types.Map) {
+	if headers.IsNull() || headers.IsUnknown() {
+		return
+	}
+
+	for k, v := range headers.Elements() {
+		if strVal, ok := v.(types.String); ok {
+			if strings.EqualFold(k, "host") {
+				req.Host = strVal.ValueString()
+				continue
+			}
+			req.Header.Set(k, strVal.ValueString())
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Add `applyRequestHeaders()` helper so `Host` (case-insensitive) in header maps sets `request.Host` instead of being ignored by Go's HTTP client
- Apply consistently across all request paths: resource create/read/destroy, data source read, ephemeral open/renew/close
- Update schema docs, add unit/integration tests, and a virtual-host example
- Fixes #79

Supersedes #97. Thanks to @JoshBlades for the original report and PR — this is a complete reimplementation on current `main` with shared helper, full lifecycle coverage, tests, and docs.

## Test plan

- [x] `go test ./internal/provider/... -count=1` (all tests pass, ~66s)
- [x] New `TestApplyRequestHeaders*` tests cover case insensitivity, non-host headers, null/unknown maps, and on-wire Host delivery via httptest
- [x] `go generate ./...` (docs regenerated with correct `page_title` suffix)


Made with [Cursor](https://cursor.com)