### PR TITLE
Upgrade HashiCorp plugin dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.4.1
+
+ENHANCEMENTS:
+
+- Upgrade HashiCorp plugin dependencies: `terraform-plugin-framework` v1.19.0, `terraform-plugin-go` v0.31.0, `terraform-plugin-testing` v1.16.0
+- Supersedes Dependabot PRs #138, #139, and #140
+
 ## 2.4.0
 
 FEATURES:


### PR DESCRIPTION
## Summary

- Coordinated upgrade of HashiCorp plugin modules to versions required for `plugin-go` v0.31.0:
  - `terraform-plugin-framework` v1.19.0
  - `terraform-plugin-go` v0.31.0
  - `terraform-plugin-testing` v1.16.0 (≥ #138’s 1.15.0 target)
- Supersedes Dependabot PRs #138, #139, and #140

`go.mod` already pinned these versions on `main` (from prior work); this PR documents the coordinated bump, adds CHANGELOG 2.4.1, and validates with the full test suite.

## Test plan

- [x] `go build ./...`
- [x] `TF_ACC=1 go test ./internal/provider/... -count=1` (full suite passed locally, ~67s)
- [x] `go generate ./...` + `git diff --exit-code`


Made with [Cursor](https://cursor.com)