### PR TITLE
Fix Create() response sanitization to match Read()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.2
+
+BUG FIXES:
+
+- Fix false drift when `Create()` stored unsanitized HTTP responses while `Read()` used sanitized JSON (fixes Create/Read mismatch for `response` and `ignore_response_fields`). Based on #141 by @rrrix.
+
 ## 2.4.1
 
 ENHANCEMENTS:

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -584,10 +584,23 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 		}
 	}
 
+	var ignoredFields []string
+	for _, v := range data.IgnoreResponseFields.Elements() {
+		if strVal, ok := v.(types.String); ok {
+			ignoredFields = append(ignoredFields, strVal.ValueString())
+		}
+	}
+
+	sanitizedResponse, err := sanitizeResponse(bodyString, ignoredFields)
+	if err != nil {
+		resp.Diagnostics.AddError("Sanitize Error", fmt.Sprintf("Failed to sanitize response: %s", err))
+		return
+	}
+
 	data.DriftMarker = types.StringValue("initial")
 	data.DestroyRequestUrlString = types.StringValue(data.DestroyUrl.ValueString())
 	data.RequestUrlString = types.StringValue(request.URL.String())
-	data.Response = types.StringValue(bodyString)
+	data.Response = types.StringValue(sanitizedResponse)
 	data.StatusCode = types.StringValue(strconv.Itoa(statusCode))
 	diags := resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/curl_resource_test.go
+++ b/internal/provider/curl_resource_test.go
@@ -644,7 +644,7 @@ func TestAccCurlResourceWithTLS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccresourceCurlTls("tls_test", server.URL, certFile, certFile, keyFile, readServer.URL, readCertFile, readCertFile, readKeyFile, destroyServer.URL, destroyCertFile, destroyCertFile, destroyKeyFile),
-				Check:  resource.TestCheckResourceAttr("terracurl_request.tls_test", "response", `{"message": "TLS test successful"}`),
+				Check:  resource.TestCheckResourceAttr("terracurl_request.tls_test", "response", `{"message":"TLS test successful"}`),
 			},
 		},
 	})
@@ -760,10 +760,96 @@ func TestAccCurlResourceWithTLSSkipVerify(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccresourceCurlTlsSkipVerify("tls_test", server.URL, certFile, keyFile, readServer.URL, readCertFile, readKeyFile, destroyServer.URL, destroyCertFile, destroyKeyFile),
-				Check:  resource.TestCheckResourceAttr("terracurl_request.tls_test", "response", `{"message": "TLS test successful"}`),
+				Check:  resource.TestCheckResourceAttr("terracurl_request.tls_test", "response", `{"message":"TLS test successful"}`),
 			},
 		},
 	})
+}
+
+func TestAccresourceCurlCreateSanitizesResponse(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/create",
+		httpmock.NewStringResponder(200, `{"zebra": "last", "alpha": "first"}`),
+	)
+
+	expectedResponse := `{"alpha":"first","zebra":"last"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceCurlCreateSanitize(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terracurl_request.sanitize_test", "response", expectedResponse),
+				),
+			},
+		},
+	})
+}
+
+func testAccresourceCurlCreateSanitize() string {
+	return `
+resource "terracurl_request" "sanitize_test" {
+  name           = "sanitize-test"
+  url            = "https://example.com/create"
+  method         = "POST"
+  request_body   = "{}"
+  response_codes = ["200"]
+  skip_destroy   = true
+}
+`
+}
+
+func TestAccresourceCurlCreateIgnoresResponseFields(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/create-ignore",
+		httpmock.NewStringResponder(200, `{"name":"keep","timestamp":"2026-01-01T00:00:00Z","request_id":"abc123"}`),
+	)
+
+	expectedResponse := `{"name":"keep"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceCurlCreateIgnoreFields(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terracurl_request.ignore_test", "response", expectedResponse),
+				),
+			},
+		},
+	})
+}
+
+func testAccresourceCurlCreateIgnoreFields() string {
+	return `
+resource "terracurl_request" "ignore_test" {
+  name           = "ignore-fields-test"
+  url            = "https://example.com/create-ignore"
+  method         = "POST"
+  request_body   = "{}"
+  response_codes = ["200"]
+  skip_destroy   = true
+
+  ignore_response_fields = ["timestamp", "request_id"]
+}
+`
 }
 
 func testMockEndpointCount(endpoint string, expected int) resource.TestCheckFunc {


### PR DESCRIPTION
## Summary

- Apply `sanitizeResponse()` in `Create()` before storing `response` state so create and read use the same JSON normalization and `ignore_response_fields` handling
- Add acceptance tests for sanitized create responses and ignored response fields
- Update TLS resource test expectations to match compact JSON stored at create time

Supersedes #141.

Thanks to @rrrix for the original report, fix, and tests. The dynamic TLS test certificate portion from #141 was already merged via #145.

## Test plan

- [x] `go build ./...`
- [x] `TF_ACC=1 go test ./internal/provider/... -count=1`
- [x] `go generate ./...`


Made with [Cursor](https://cursor.com)