### PR TITLE
fix: improve read support (merge conflict resolution for #149)

### DIFF
--- a/internal/provider/curl_data_source.go
+++ b/internal/provider/curl_data_source.go
@@ -256,14 +256,7 @@ func (d *CurlDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 			bodyString = "{}"
 		}
 
-		var responseCodes []string
-		for _, v := range data.ResponseCodes.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				responseCodes = append(responseCodes, strVal.ValueString())
-			}
-		}
-
-		if responseCodeChecker(responseCodes, strconv.Itoa(statusCode)) {
+		if responseCodeChecker(data.ResponseCodes, statusCode) {
 			break
 		}
 

--- a/internal/provider/curl_ephemeral_resource.go
+++ b/internal/provider/curl_ephemeral_resource.go
@@ -483,14 +483,7 @@ func (e *EphemeralCurlResource) Open(ctx context.Context, req ephemeral.OpenRequ
 			bodyString = "{}"
 		}
 
-		var responseCodes []string
-		for _, v := range data.ResponseCodes.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				responseCodes = append(responseCodes, strVal.ValueString())
-			}
-		}
-
-		if responseCodeChecker(responseCodes, strconv.Itoa(statusCode)) {
+		if responseCodeChecker(data.ResponseCodes, statusCode) {
 			break
 		}
 
@@ -1143,14 +1136,7 @@ func (e *EphemeralCurlResource) Renew(ctx context.Context, req ephemeral.RenewRe
 			bodyString = "{}"
 		}
 
-		var responseCodes []string
-		for _, v := range privateData.RenewResponseCodes.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				responseCodes = append(responseCodes, strVal.ValueString())
-			}
-		}
-
-		if responseCodeChecker(responseCodes, strconv.Itoa(statusCode)) {
+		if responseCodeChecker(privateData.RenewResponseCodes, statusCode) {
 			break
 		}
 
@@ -1497,19 +1483,10 @@ func (e *EphemeralCurlResource) Close(ctx context.Context, req ephemeral.CloseRe
 			return
 		}
 
-		var expectedCodes []string
 		tflog.Debug(ctx, fmt.Sprintf("private data response code list: %v", privateData.CloseResponseCodes.Elements()))
-		for _, v := range privateData.CloseResponseCodes.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				expectedCodes = append(expectedCodes, strVal.ValueString())
-			}
-		}
-
-		tflog.Debug(ctx, fmt.Sprintf("response code received: %v", statusCode))
-		tflog.Debug(ctx, fmt.Sprintf("expected response code received: %v", expectedCodes))
 
 		// Validate Response Code
-		if responseCodeChecker(expectedCodes, strconv.Itoa(statusCode)) {
+		if responseCodeChecker(privateData.CloseResponseCodes, statusCode) {
 			tflog.Debug(ctx, "Close request completed successfully")
 			break
 		} else {

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -721,7 +721,7 @@ func (r *CurlResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	// Drift detection
-	if oldSanitized != sanitizedResponse {
+	if !responseCodeChecker(data.ReadResponseCodes, httpResp.StatusCode) || (oldSanitized != "null" && oldSanitized != sanitizedResponse) {
 		tflog.Warn(ctx, "Drift detected: Response has changed, marking for recreation.")
 		data.DriftMarker = types.StringValue(time.Now().Format(time.RFC3339Nano))
 	} else {

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -574,14 +574,7 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 			bodyString = "{}"
 		}
 
-		var responseCodes []string
-		for _, v := range data.ResponseCodes.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				responseCodes = append(responseCodes, strVal.ValueString())
-			}
-		}
-
-		if responseCodeChecker(responseCodes, strconv.Itoa(statusCode)) {
+		if responseCodeChecker(data.ResponseCodes, statusCode) {
 			break
 		}
 
@@ -875,15 +868,8 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 			return
 		}
 
-		var expectedCodes []string
-		for _, v := range data.DestroyResponseCodes.Elements() {
-			if strVal, ok := v.(types.String); ok {
-				expectedCodes = append(expectedCodes, strVal.ValueString())
-			}
-		}
-
 		// Validate Response Code
-		if responseCodeChecker(expectedCodes, strconv.Itoa(statusCode)) {
+		if responseCodeChecker(data.DestroyResponseCodes, statusCode) {
 			tflog.Debug(ctx, "Destroy request completed successfully")
 			break
 		} else {

--- a/internal/provider/utilities.go
+++ b/internal/provider/utilities.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -39,9 +40,18 @@ func sanitizeResponse(response string, fieldsToIgnore []string) (string, error) 
 	return string(filteredBytes), nil
 }
 
-func responseCodeChecker(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
+func responseCodeChecker(expectedStatusCodes types.List, receivedStatusCode int) bool {
+	var responseStatusCodes []string
+	for _, v := range expectedStatusCodes.Elements() {
+		if strVal, ok := v.(types.String); ok {
+			responseStatusCodes = append(responseStatusCodes, strVal.ValueString())
+		}
+	}
+
+	var receivedStatusCodeAsInt = strconv.Itoa(receivedStatusCode)
+
+	for _, v := range responseStatusCodes {
+		if v == receivedStatusCodeAsInt {
 			return true
 		}
 	}

--- a/internal/provider/utilities_test.go
+++ b/internal/provider/utilities_test.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -51,17 +53,19 @@ func TestSanitizeResponse(t *testing.T) {
 func TestResponseCodeChecker(t *testing.T) {
 	tests := []struct {
 		name     string
-		codes    []string
-		input    string
+		codes    []attr.Value
+		input    int
 		expected bool
 	}{
-		{"Value Present", []string{"200", "404", "500"}, "404", true},
-		{"Value Absent", []string{"200", "500"}, "404", false},
+		{"Value Present", []attr.Value{types.StringValue("200"), types.StringValue("404"), types.StringValue("500")}, 404, true},
+		{"Value Absent", []attr.Value{types.StringValue("200"), types.StringValue("500")}, 404, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := responseCodeChecker(tt.codes, tt.input)
+			var listValue types.List
+			listValue, _ = types.ListValue(types.StringType, tt.codes)
+			result := responseCodeChecker(listValue, tt.input)
 			if result != tt.expected {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
 			}


### PR DESCRIPTION
## Summary

Resolves merge conflicts from #149 onto current `main`.

- Keep `responseCodeChecker(types.List, int)` refactor from #149
- Keep sensitive response helpers and drift logic from #155
- Read drift now checks `read_response_codes` status in addition to body comparison
- Update `curl_action.go` for refactored checker signature

Supersedes / replaces conflict resolution for #149 by @JackSlateur.

## Test plan

- [x] `go build ./...`
- [x] Unit tests for responseCodeChecker and Read drift toggle
- [ ] Full CI matrix (pending)


Made with [Cursor](https://cursor.com)