### PR TITLE
Fix UpgradeState panic when prior state is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.5.3
+
+BUG FIXES:
+
+- Fix panic upgrading `terracurl_request` state from provider v1.x when `UpgradeResourceState` receives nil prior state. Closes #134.
+
 ## 2.5.2
 
 BUG FIXES:

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -1020,13 +1020,24 @@ func (r *CurlResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 
 				var oldState CurlResourceModel
 
-				// First, try the normal state extraction
-				diags := req.State.Get(ctx, &oldState)
+				var diags diag.Diagnostics
+				useRawState := req.State == nil
 
-				if diags.HasError() {
-					tflog.Info(ctx, "Direct state extraction failed, attempting to extract values from raw state", map[string]interface{}{
-						"errors": diags.Errors(),
-					})
+				if !useRawState {
+					diags = req.State.Get(ctx, &oldState)
+					if diags.HasError() {
+						useRawState = true
+					}
+				}
+
+				if useRawState {
+					if req.State == nil {
+						tflog.Info(ctx, "Prior state is nil, attempting to extract values from raw state")
+					} else {
+						tflog.Info(ctx, "Direct state extraction failed, attempting to extract values from raw state", map[string]interface{}{
+							"errors": diags.Errors(),
+						})
+					}
 
 					// Try to extract what we can from the raw state
 					if req.RawState != nil && len(req.RawState.JSON) > 0 {

--- a/internal/provider/curl_resource_test.go
+++ b/internal/provider/curl_resource_test.go
@@ -1762,3 +1762,86 @@ func TestCurlResource_StateUpgrade_EmptyDestroyParameters(t *testing.T) {
 		t.Errorf("Expected id to be preserved, got '%s'", upgradedState.Id.ValueString())
 	}
 }
+
+func TestCurlResource_StateUpgrade_NilRequestState(t *testing.T) {
+	ctx := context.Background()
+	r := &CurlResource{}
+
+	upgraders := r.UpgradeState(ctx)
+	upgrader, ok := upgraders[0]
+	if !ok {
+		t.Fatal("No upgrader found for version 0")
+	}
+
+	// v1.2-style state JSON from issue #134 (provider SDK -> framework upgrade).
+	rawStateJSON := `{
+		"id": "example-get-call",
+		"name": "example-get-call",
+		"url": "https://jsonplaceholder.typicode.com/posts/1",
+		"method": "GET",
+		"headers": {"Content-Type": "application/json"},
+		"response_codes": ["200", "201"],
+		"response": "{\"userId\":1,\"id\":1,\"title\":\"sunt aut facere\",\"body\":\"quia et suscipit\"}",
+		"status_code": "200"
+	}`
+
+	rUpgrade := &CurlResource{}
+	schemaResp := &resource2.SchemaResponse{}
+	rUpgrade.Schema(ctx, resource2.SchemaRequest{}, schemaResp)
+	schemaVar := schemaResp.Schema
+
+	req := resource2.UpgradeStateRequest{
+		State: nil,
+		RawState: &tfprotov6.RawState{
+			JSON: []byte(rawStateJSON),
+		},
+	}
+
+	resp := &resource2.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: schemaVar,
+		},
+	}
+
+	upgrader.StateUpgrader(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("upgrade failed: %v", resp.Diagnostics)
+	}
+
+	var upgradedState CurlResourceModel
+	diags := resp.State.Get(ctx, &upgradedState)
+	if diags.HasError() {
+		t.Fatalf("error getting upgraded state: %v", diags)
+	}
+
+	if upgradedState.Id.ValueString() != "example-get-call" {
+		t.Errorf("Expected id 'example-get-call', got '%s'", upgradedState.Id.ValueString())
+	}
+	if upgradedState.Name.ValueString() != "example-get-call" {
+		t.Errorf("Expected name 'example-get-call', got '%s'", upgradedState.Name.ValueString())
+	}
+	if upgradedState.Url.ValueString() != "https://jsonplaceholder.typicode.com/posts/1" {
+		t.Errorf("Expected url preserved, got '%s'", upgradedState.Url.ValueString())
+	}
+	if upgradedState.Method.ValueString() != "GET" {
+		t.Errorf("Expected method 'GET', got '%s'", upgradedState.Method.ValueString())
+	}
+	if upgradedState.Headers.IsNull() {
+		t.Error("Expected headers to be preserved")
+	}
+	if upgradedState.ResponseCodes.IsNull() {
+		t.Error("Expected response_codes to be preserved")
+	}
+	if !upgradedState.SkipRead.ValueBool() {
+		t.Error("Expected skip_read to be set to true in v1 upgrade")
+	}
+	if !upgradedState.ReadUrl.IsNull() {
+		t.Error("Expected read_url to be null in v1 upgrade")
+	}
+	if !upgradedState.ReadResponseCodes.IsNull() {
+		t.Error("Expected read_response_codes to be null in v1 upgrade")
+	}
+	if upgradedState.ResponseSensitive.IsNull() || upgradedState.ResponseSensitive.ValueBool() {
+		t.Error("Expected response_sensitive to default to false")
+	}
+}


### PR DESCRIPTION
## Summary
- Guard `UpgradeState` so `req.State.Get` is skipped when `req.State` is nil
- Fall back to existing `RawState` extraction (v1.x SDK → v2.x framework upgrade path)
- Add regression test matching issue #134 reporter scenario
- CHANGELOG 2.5.3

Closes #134

## Test plan
- [x] `go test ./internal/provider/... -run StateUpgrade -count=1`
- [ ] CI

Made with [Cursor](https://cursor.com)