### PR TITLE
Add write-only headers and request bodies (Closes #115, Closes #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.8.0
+
+ENHANCEMENTS:
+
+- Add write-only headers and request bodies on `terracurl_request` resources with `_wo_version` companions and private-state snapshots for read/destroy. Requires Terraform 1.11+. Closes #115, #116.
+
 ## 2.7.0
 
 ENHANCEMENTS:

--- a/docs/guides/default_headers.md
+++ b/docs/guides/default_headers.md
@@ -80,7 +80,7 @@ Provider headers win on key collision. This ensures a fresh provider token repla
 ## Limitations
 
 - Tokens set only in resource `headers` or `destroy_headers` are still persisted in state. For destroy-only refresh, move auth to `default_headers` or run `terraform apply` before destroy to update state.
-- Write-only resource headers (see issue #115) are a separate follow-up to avoid persisting secrets in state entirely.
+- Write-only resource headers (see the [Write-Only Headers and Request Bodies guide](write_only)) avoid persisting secrets in state entirely.
 - `default_headers` is marked sensitive in the provider schema and will not appear in plan output.
 
 ## Workaround without default_headers

--- a/docs/guides/digest_auth.md
+++ b/docs/guides/digest_auth.md
@@ -87,7 +87,7 @@ If credentials are set only in `destroy_digest_auth`, those values are persisted
 
 - HTTP Basic authentication is not built in; set a static `Authorization: Basic ...` header manually or use provider `default_headers`.
 - NTLM, Kerberos, and other enterprise proxy authentication mechanisms remain unsupported. See the [HTTP Proxy Support guide](proxy).
-- Digest credentials configured on resources are stored in Terraform state (marked sensitive). Write-only credentials are tracked separately in issue #115.
+- Digest credentials configured on resources are stored in Terraform state (marked sensitive). For credentials that must not appear in state, use write-only headers or provider `default_headers` where applicable. See the [Write-Only Headers and Request Bodies guide](write_only).
 - Custom `realm` or algorithm tuning is not exposed unless a real API requires it.
 
 ## Digest vs default_headers

--- a/docs/guides/write_only.md
+++ b/docs/guides/write_only.md
@@ -1,0 +1,82 @@
+---
+page_title: "Write-Only Headers and Request Bodies"
+subcategory: "Guides"
+description: |-
+  Use write-only headers and request bodies on terracurl_request resources to send secrets without persisting them in Terraform state.
+---
+
+# Write-Only Headers and Request Bodies
+
+Terraform 1.11+ supports **write-only arguments**: values supplied in configuration that are used during apply but are **not stored in plan or state JSON**. TerraCurl exposes this for `terracurl_request` resource headers and request bodies on create, read, and destroy operations.
+
+Use write-only attributes when secrets must not appear in `terraform show`, remote state, or version control–backed state files — even when marked `sensitive`.
+
+## Requirements
+
+- Terraform **1.11 or later**
+- `terracurl_request` **resource only** (write-only is not available on data sources, actions, or ephemeral resources)
+
+## Create example
+
+```terraform
+resource "terracurl_request" "example" {
+  name   = "example"
+  url    = "https://api.example.com/resource"
+  method = "PUT"
+
+  headers_wo = {
+    X-Vault-Token = var.vault_token
+  }
+  headers_wo_version = 1
+
+  request_body_wo = jsonencode({
+    password = var.password
+  })
+  request_body_wo_version = 1
+
+  response_codes = [200]
+  skip_read      = true
+}
+```
+
+Do **not** set both `headers` and `headers_wo` (or `request_body` and `request_body_wo`) on the same operation. TerraCurl rejects conflicting pairs at plan time.
+
+## Per-operation attributes
+
+| Operation | Headers | Body | Version attributes |
+|-----------|---------|------|--------------------|
+| Create | `headers_wo` | `request_body_wo` | `headers_wo_version`, `request_body_wo_version` |
+| Read | `read_headers_wo` | `read_request_body_wo` | `read_headers_wo_version`, `read_request_body_wo_version` |
+| Destroy | `destroy_headers_wo` | `destroy_request_body_wo` | `destroy_headers_wo_version`, `destroy_request_body_wo_version` |
+
+Version attributes are stored in state (not write-only). Increment a `_wo_version` when you change the corresponding write-only value so TerraCurl refreshes the snapshotted credentials on update.
+
+## Read and destroy without config access
+
+Terraform does not pass resource configuration to Read or Delete RPCs. TerraCurl **snapshots** read/destroy write-only values into provider private state during Create (and refreshes the snapshot on Update when a `_wo_version` changes). Private state is not shown in plan output, but it is persisted with the resource.
+
+For rotating destroy credentials without storing them in resource state, consider [provider `default_headers`](default_headers) instead.
+
+## Updating write-only values
+
+TerraCurl does not re-issue the create HTTP call on in-place update. To change a write-only body or header after initial apply:
+
+1. Update the write-only value in configuration
+2. Increment the matching `_wo_version` attribute
+3. Run `terraform apply`
+
+If the API must be called again with the new payload, trigger replacement through other attribute changes or taint the resource.
+
+## Comparison with other options
+
+| Approach | In state? | In plan? | Destroy refresh |
+|----------|-----------|----------|-----------------|
+| `headers` / `request_body` | Yes (sensitive still stored) | Hidden if sensitive | From state (can go stale) |
+| `headers_wo` / `request_body_wo` | No | No | From private snapshot |
+| Provider `default_headers` | No (provider config) | No | Re-evaluated every run |
+
+## Limitations
+
+- Resource-only; use `default_headers` or sensitive attributes on data sources, actions, and ephemeral resources
+- Private state snapshot is not zero-persistence storage
+- Digest credentials remain stateful today; write-only digest auth is future work

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,4 +163,45 @@ resource "terracurl_request" "example" {
 }
 ```
 
+## Write-Only Headers and Request Bodies
+
+TerraCurl supports write-only `headers_wo` and `request_body_wo` attributes on `terracurl_request` resources (Terraform 1.11+). Values are sent on HTTP calls but are not stored in Terraform state.
+
+See the [Write-Only Headers and Request Bodies guide](guides/write_only) for version attributes, read/destroy private-state behavior, and comparison with `default_headers`.
+
+```terraform
+# Write-only headers and bodies require Terraform 1.11+.
+#
+# Values are used for HTTP calls but not stored in Terraform state.
+# Increment *_wo_version when changing a write-only value.
+
+resource "terracurl_request" "example" {
+  name   = "example"
+  url    = "https://httpbin.org/put"
+  method = "PUT"
+
+  headers_wo = {
+    Authorization = "Bearer ${var.api_token}"
+  }
+  headers_wo_version = 1
+
+  request_body_wo = jsonencode({
+    password = var.password
+  })
+  request_body_wo_version = 1
+
+  response_codes = [200]
+  skip_read      = true
+
+  destroy_url            = "https://httpbin.org/delete"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200]
+
+  destroy_headers_wo = {
+    Authorization = "Bearer ${var.api_token}"
+  }
+  destroy_headers_wo_version = 1
+}
+```
+
 ## Limitations

--- a/docs/resources/request.md
+++ b/docs/resources/request.md
@@ -25,6 +25,8 @@ When `skip_read` is `false` and `read_url`, `read_method`, and `read_response_co
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `ca_cert_directory` (String) Path to a directory on local disk that contains one or more certificate files that will be used to validate the certificate presented by the server
 - `ca_cert_file` (String) Path to a file on local disk that will be used to validate the certificate presented by the server
 - `cert_file` (String) Path to a file on local disk that contains the PEM-encoded certificate to present to the server
@@ -33,10 +35,14 @@ When `skip_read` is `false` and `read_url`, `read_method`, and `read_response_co
 - `destroy_cert_file` (String) Path to a file on local disk that contains the PEM-encoded certificate to present to the server for the destroy call
 - `destroy_digest_auth` (Attributes, Sensitive) HTTP Digest authentication credentials for the destroy request. Overrides provider `default_digest_auth` when configured. (see [below for nested schema](#nestedatt--destroy_digest_auth))
 - `destroy_headers` (Map of String) Map of headers to attach to the destroy API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
+- `destroy_headers_wo` (Map of String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only headers for the destroy call. Snapshotted in provider private state for use during destroy.
+- `destroy_headers_wo_version` (Number) Increment to trigger refreshing snapshotted `destroy_headers_wo` values.
 - `destroy_key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued for the destroy call
 - `destroy_max_retry` (Number) Maximum number of tries until it is marked as failed for the destroy call
 - `destroy_method` (String) Destroy HTTP method to use in the API call
 - `destroy_request_body` (String) A request body to attach to the destroy API call
+- `destroy_request_body_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only request body for the destroy call. Not stored in Terraform state.
+- `destroy_request_body_wo_version` (Number) Increment to trigger applying an updated `destroy_request_body_wo` value.
 - `destroy_request_parameters` (Map of String) Map of parameters to attach to the destroy API call
 - `destroy_response_codes` (List of String) A list of expected response codes for the destroy call
 - `destroy_retry_interval` (Number) Interval between each attempt for the destroy call
@@ -45,6 +51,8 @@ When `skip_read` is `false` and `read_url`, `read_method`, and `read_response_co
 - `destroy_url` (String) Destroy API endpoint to call
 - `digest_auth` (Attributes, Sensitive) HTTP Digest authentication credentials for the create request. Overrides provider `default_digest_auth` when configured. (see [below for nested schema](#nestedatt--digest_auth))
 - `headers` (Map of String) Map of headers to attach to the API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
+- `headers_wo` (Map of String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only headers for the create call. Not stored in Terraform state. Requires Terraform 1.11 or later.
+- `headers_wo_version` (Number) Increment to trigger applying updated `headers_wo` values.
 - `ignore_response_fields` (List of String) List of JSON fields to ignore during drift detection.
 - `key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued
 - `max_retry` (Number) Maximum number of tries until it is marked as failed
@@ -53,14 +61,20 @@ When `skip_read` is `false` and `read_url`, `read_method`, and `read_response_co
 - `read_cert_file` (String) Path to a PEM-encoded certificate for the read request (TLS).
 - `read_digest_auth` (Attributes, Sensitive) HTTP Digest authentication credentials for the read request. Overrides provider `default_digest_auth` when configured. (see [below for nested schema](#nestedatt--read_digest_auth))
 - `read_headers` (Map of String) Map of headers for the read request. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
+- `read_headers_wo` (Map of String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only headers for the read call. Snapshotted in provider private state for drift detection.
+- `read_headers_wo_version` (Number) Increment to trigger refreshing snapshotted `read_headers_wo` values.
 - `read_key_file` (String) Path to a PEM-encoded private key for the read request (TLS).
 - `read_method` (String) HTTP method for reading resource state. Required if `skip_read` is false.
 - `read_parameters` (Map of String) Optional request parameters to add to the URL
 - `read_request_body` (String) Optional request body to use for the read request.
+- `read_request_body_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only request body for the read call. Snapshotted in provider private state for drift detection.
+- `read_request_body_wo_version` (Number) Increment to trigger refreshing snapshotted `read_request_body_wo` values.
 - `read_response_codes` (List of String) Expected response codes for the read request. Required if `skip_read` is false.
 - `read_skip_tls_verify` (Boolean) Skip TLS verification for the read request.
 - `read_url` (String) API endpoint for reading resource state. Required if `skip_read` is false.
 - `request_body` (String) A request body to attach to the API call
+- `request_body_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only request body for the create call. Not stored in Terraform state. Requires Terraform 1.11 or later.
+- `request_body_wo_version` (Number) Increment to trigger applying an updated `request_body_wo` value.
 - `request_parameters` (Map of String) Map of parameters to attach to the API call
 - `response_sensitive` (Boolean) Set to `true` to treat the response as sensitive. When enabled, the response body is written to `sensitive_response` (a sensitive attribute) and `response` is left empty so that secret values are not displayed in plan output. Defaults to `false` to preserve existing behavior.
 - `retry_interval` (Number) Interval between each attempt

--- a/examples/provider/write_only_example.tf
+++ b/examples/provider/write_only_example.tf
@@ -1,0 +1,32 @@
+# Write-only headers and bodies require Terraform 1.11+.
+#
+# Values are used for HTTP calls but not stored in Terraform state.
+# Increment *_wo_version when changing a write-only value.
+
+resource "terracurl_request" "example" {
+  name   = "example"
+  url    = "https://httpbin.org/put"
+  method = "PUT"
+
+  headers_wo = {
+    Authorization = "Bearer ${var.api_token}"
+  }
+  headers_wo_version = 1
+
+  request_body_wo = jsonencode({
+    password = var.password
+  })
+  request_body_wo_version = 1
+
+  response_codes = [200]
+  skip_read      = true
+
+  destroy_url            = "https://httpbin.org/delete"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200]
+
+  destroy_headers_wo = {
+    Authorization = "Bearer ${var.api_token}"
+  }
+  destroy_headers_wo_version = 1
+}

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -23,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -47,60 +50,72 @@ type CurlResource struct {
 
 // CurlResourceModel describes the resource data model.
 type CurlResourceModel struct {
-	Id                       types.String     `tfsdk:"id"`
-	Name                     types.String     `tfsdk:"name"`
-	Url                      types.String     `tfsdk:"url"`
-	Method                   types.String     `tfsdk:"method"`
-	RequestBody              types.String     `tfsdk:"request_body"`
-	Headers                  types.Map        `tfsdk:"headers"`
-	DigestAuth               *DigestAuthModel `tfsdk:"digest_auth"`
-	RequestParameters        types.Map        `tfsdk:"request_parameters"`
-	RequestUrlString         types.String     `tfsdk:"request_url_string"`
-	CertFile                 types.String     `tfsdk:"cert_file"`
-	KeyFile                  types.String     `tfsdk:"key_file"`
-	CaCertFile               types.String     `tfsdk:"ca_cert_file"`
-	CaCertDirectory          types.String     `tfsdk:"ca_cert_directory"`
-	SkipTlsVerify            types.Bool       `tfsdk:"skip_tls_verify"`
-	RetryInterval            types.Int64      `tfsdk:"retry_interval"`
-	MaxRetry                 types.Int64      `tfsdk:"max_retry"`
-	Timeout                  types.Int64      `tfsdk:"timeout"`
-	Response                 types.String     `tfsdk:"response"`
-	SensitiveResponse        types.String     `tfsdk:"sensitive_response"`
-	ResponseSensitive        types.Bool       `tfsdk:"response_sensitive"`
-	ResponseCodes            types.List       `tfsdk:"response_codes"`
-	StatusCode               types.String     `tfsdk:"status_code"`
-	SkipDestroy              types.Bool       `tfsdk:"skip_destroy"`
-	DestroyUrl               types.String     `tfsdk:"destroy_url"`
-	DestroyMethod            types.String     `tfsdk:"destroy_method"`
-	DestroyRequestBody       types.String     `tfsdk:"destroy_request_body"`
-	DestroyHeaders           types.Map        `tfsdk:"destroy_headers"`
-	DestroyDigestAuth        *DigestAuthModel `tfsdk:"destroy_digest_auth"`
-	DestroyRequestParameters types.Map        `tfsdk:"destroy_request_parameters"`
-	DestroyRequestUrlString  types.String     `tfsdk:"destroy_request_url_string"`
-	DestroyCertFile          types.String     `tfsdk:"destroy_cert_file"`
-	DestroyKeyFile           types.String     `tfsdk:"destroy_key_file"`
-	DestroyCaCertFile        types.String     `tfsdk:"destroy_ca_cert_file"`
-	DestroyCaCertDirectory   types.String     `tfsdk:"destroy_ca_cert_directory"`
-	DestroySkipTlsVerify     types.Bool       `tfsdk:"destroy_skip_tls_verify"`
-	DestroyRetryInterval     types.Int64      `tfsdk:"destroy_retry_interval"`
-	DestroyMaxRetry          types.Int64      `tfsdk:"destroy_max_retry"`
-	DestroyTimeout           types.Int64      `tfsdk:"destroy_timeout"`
-	DestroyResponseCodes     types.List       `tfsdk:"destroy_response_codes"`
-	SkipRead                 types.Bool       `tfsdk:"skip_read"`
-	ReadUrl                  types.String     `tfsdk:"read_url"`
-	ReadMethod               types.String     `tfsdk:"read_method"`
-	ReadHeaders              types.Map        `tfsdk:"read_headers"`
-	ReadDigestAuth           *DigestAuthModel `tfsdk:"read_digest_auth"`
-	ReadParameters           types.Map        `tfsdk:"read_parameters"`
-	ReadRequestBody          types.String     `tfsdk:"read_request_body"`
-	ReadCertFile             types.String     `tfsdk:"read_cert_file"`
-	ReadKeyFile              types.String     `tfsdk:"read_key_file"`
-	ReadCaCertFile           types.String     `tfsdk:"read_ca_cert_file"`
-	ReadCaCertDirectory      types.String     `tfsdk:"read_ca_cert_directory"`
-	ReadSkipTlsVerify        types.Bool       `tfsdk:"read_skip_tls_verify"`
-	ReadResponseCodes        types.List       `tfsdk:"read_response_codes"`
-	DriftMarker              types.String     `tfsdk:"drift_marker"`
-	IgnoreResponseFields     types.List       `tfsdk:"ignore_response_fields"`
+	Id                          types.String     `tfsdk:"id"`
+	Name                        types.String     `tfsdk:"name"`
+	Url                         types.String     `tfsdk:"url"`
+	Method                      types.String     `tfsdk:"method"`
+	RequestBody                 types.String     `tfsdk:"request_body"`
+	RequestBodyWo               types.String     `tfsdk:"request_body_wo"`
+	RequestBodyWoVersion        types.Int64      `tfsdk:"request_body_wo_version"`
+	Headers                     types.Map        `tfsdk:"headers"`
+	HeadersWo                   types.Map        `tfsdk:"headers_wo"`
+	HeadersWoVersion            types.Int64      `tfsdk:"headers_wo_version"`
+	DigestAuth                  *DigestAuthModel `tfsdk:"digest_auth"`
+	RequestParameters           types.Map        `tfsdk:"request_parameters"`
+	RequestUrlString            types.String     `tfsdk:"request_url_string"`
+	CertFile                    types.String     `tfsdk:"cert_file"`
+	KeyFile                     types.String     `tfsdk:"key_file"`
+	CaCertFile                  types.String     `tfsdk:"ca_cert_file"`
+	CaCertDirectory             types.String     `tfsdk:"ca_cert_directory"`
+	SkipTlsVerify               types.Bool       `tfsdk:"skip_tls_verify"`
+	RetryInterval               types.Int64      `tfsdk:"retry_interval"`
+	MaxRetry                    types.Int64      `tfsdk:"max_retry"`
+	Timeout                     types.Int64      `tfsdk:"timeout"`
+	Response                    types.String     `tfsdk:"response"`
+	SensitiveResponse           types.String     `tfsdk:"sensitive_response"`
+	ResponseSensitive           types.Bool       `tfsdk:"response_sensitive"`
+	ResponseCodes               types.List       `tfsdk:"response_codes"`
+	StatusCode                  types.String     `tfsdk:"status_code"`
+	SkipDestroy                 types.Bool       `tfsdk:"skip_destroy"`
+	DestroyUrl                  types.String     `tfsdk:"destroy_url"`
+	DestroyMethod               types.String     `tfsdk:"destroy_method"`
+	DestroyRequestBody          types.String     `tfsdk:"destroy_request_body"`
+	DestroyRequestBodyWo        types.String     `tfsdk:"destroy_request_body_wo"`
+	DestroyRequestBodyWoVersion types.Int64      `tfsdk:"destroy_request_body_wo_version"`
+	DestroyHeaders              types.Map        `tfsdk:"destroy_headers"`
+	DestroyHeadersWo            types.Map        `tfsdk:"destroy_headers_wo"`
+	DestroyHeadersWoVersion     types.Int64      `tfsdk:"destroy_headers_wo_version"`
+	DestroyDigestAuth           *DigestAuthModel `tfsdk:"destroy_digest_auth"`
+	DestroyRequestParameters    types.Map        `tfsdk:"destroy_request_parameters"`
+	DestroyRequestUrlString     types.String     `tfsdk:"destroy_request_url_string"`
+	DestroyCertFile             types.String     `tfsdk:"destroy_cert_file"`
+	DestroyKeyFile              types.String     `tfsdk:"destroy_key_file"`
+	DestroyCaCertFile           types.String     `tfsdk:"destroy_ca_cert_file"`
+	DestroyCaCertDirectory      types.String     `tfsdk:"destroy_ca_cert_directory"`
+	DestroySkipTlsVerify        types.Bool       `tfsdk:"destroy_skip_tls_verify"`
+	DestroyRetryInterval        types.Int64      `tfsdk:"destroy_retry_interval"`
+	DestroyMaxRetry             types.Int64      `tfsdk:"destroy_max_retry"`
+	DestroyTimeout              types.Int64      `tfsdk:"destroy_timeout"`
+	DestroyResponseCodes        types.List       `tfsdk:"destroy_response_codes"`
+	SkipRead                    types.Bool       `tfsdk:"skip_read"`
+	ReadUrl                     types.String     `tfsdk:"read_url"`
+	ReadMethod                  types.String     `tfsdk:"read_method"`
+	ReadHeaders                 types.Map        `tfsdk:"read_headers"`
+	ReadHeadersWo               types.Map        `tfsdk:"read_headers_wo"`
+	ReadHeadersWoVersion        types.Int64      `tfsdk:"read_headers_wo_version"`
+	ReadDigestAuth              *DigestAuthModel `tfsdk:"read_digest_auth"`
+	ReadParameters              types.Map        `tfsdk:"read_parameters"`
+	ReadRequestBody             types.String     `tfsdk:"read_request_body"`
+	ReadRequestBodyWo           types.String     `tfsdk:"read_request_body_wo"`
+	ReadRequestBodyWoVersion    types.Int64      `tfsdk:"read_request_body_wo_version"`
+	ReadCertFile                types.String     `tfsdk:"read_cert_file"`
+	ReadKeyFile                 types.String     `tfsdk:"read_key_file"`
+	ReadCaCertFile              types.String     `tfsdk:"read_ca_cert_file"`
+	ReadCaCertDirectory         types.String     `tfsdk:"read_ca_cert_directory"`
+	ReadSkipTlsVerify           types.Bool       `tfsdk:"read_skip_tls_verify"`
+	ReadResponseCodes           types.List       `tfsdk:"read_response_codes"`
+	DriftMarker                 types.String     `tfsdk:"drift_marker"`
+	IgnoreResponseFields        types.List       `tfsdk:"ignore_response_fields"`
 }
 
 func (r *CurlResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -144,7 +159,12 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("request_body_wo")),
+				},
 			},
+			"request_body_wo":         writeOnlyBodySchema("Write-only request body for the create call. Not stored in Terraform state. Requires Terraform 1.11 or later."),
+			"request_body_wo_version": writeOnlyVersionSchema("Increment to trigger applying an updated `request_body_wo` value."),
 			"headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
@@ -152,8 +172,13 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.Map{
+					mapvalidator.PreferWriteOnlyAttribute(path.MatchRoot("headers_wo")),
+				},
 			},
-			"digest_auth": resourceDigestAuthSchema("HTTP Digest authentication credentials for the create request. Overrides provider `default_digest_auth` when configured."),
+			"headers_wo":         writeOnlyHeadersSchema("Write-only headers for the create call. Not stored in Terraform state. Requires Terraform 1.11 or later."),
+			"headers_wo_version": writeOnlyVersionSchema("Increment to trigger applying updated `headers_wo` values."),
+			"digest_auth":        resourceDigestAuthSchema("HTTP Digest authentication credentials for the create request. Overrides provider `default_digest_auth` when configured."),
 			"request_parameters": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
@@ -269,7 +294,12 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("destroy_request_body_wo")),
+				},
 			},
+			"destroy_request_body_wo":         writeOnlyBodySchema("Write-only request body for the destroy call. Not stored in Terraform state."),
+			"destroy_request_body_wo_version": writeOnlyVersionSchema("Increment to trigger applying an updated `destroy_request_body_wo` value."),
 			"destroy_headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
@@ -277,8 +307,13 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.Map{
+					mapvalidator.PreferWriteOnlyAttribute(path.MatchRoot("destroy_headers_wo")),
+				},
 			},
-			"destroy_digest_auth": resourceDigestAuthSchema("HTTP Digest authentication credentials for the destroy request. Overrides provider `default_digest_auth` when configured."),
+			"destroy_headers_wo":         writeOnlyHeadersSchema("Write-only headers for the destroy call. Snapshotted in provider private state for use during destroy."),
+			"destroy_headers_wo_version": writeOnlyVersionSchema("Increment to trigger refreshing snapshotted `destroy_headers_wo` values."),
+			"destroy_digest_auth":        resourceDigestAuthSchema("HTTP Digest authentication credentials for the destroy request. Overrides provider `default_digest_auth` when configured."),
 			"destroy_request_parameters": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
@@ -367,13 +402,23 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				ElementType:         types.StringType,
 				Optional:            true,
 				MarkdownDescription: "Map of headers for the read request." + hostHeaderMarkdownSuffix,
+				Validators: []validator.Map{
+					mapvalidator.PreferWriteOnlyAttribute(path.MatchRoot("read_headers_wo")),
+				},
 			},
-			"read_digest_auth": resourceDigestAuthSchema("HTTP Digest authentication credentials for the read request. Overrides provider `default_digest_auth` when configured."),
+			"read_headers_wo":         writeOnlyHeadersSchema("Write-only headers for the read call. Snapshotted in provider private state for drift detection."),
+			"read_headers_wo_version": writeOnlyVersionSchema("Increment to trigger refreshing snapshotted `read_headers_wo` values."),
+			"read_digest_auth":        resourceDigestAuthSchema("HTTP Digest authentication credentials for the read request. Overrides provider `default_digest_auth` when configured."),
 
 			"read_request_body": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Optional request body to use for the read request.",
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("read_request_body_wo")),
+				},
 			},
+			"read_request_body_wo":         writeOnlyBodySchema("Write-only request body for the read call. Snapshotted in provider private state for drift detection."),
+			"read_request_body_wo_version": writeOnlyVersionSchema("Increment to trigger refreshing snapshotted `read_request_body_wo` values."),
 
 			"read_parameters": schema.MapAttribute{
 				Optional:            true,
@@ -459,6 +504,17 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	resp.Diagnostics.Append(mergeWriteOnlyFromConfig(ctx, req.Config, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var configModel CurlResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if !data.SkipRead.IsNull() && !data.SkipRead.ValueBool() {
 		tflog.Debug(ctx, "skip_read validation triggered", map[string]interface{}{
 			"skip_read_is_null":   data.SkipRead.IsNull(),
@@ -513,7 +569,7 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	reqBody := []byte(data.RequestBody.ValueString())
+	reqBody, usedWriteOnlyBody := resolveRequestBody(data.RequestBody, data.RequestBodyWo)
 	request, err := http.NewRequest(data.Method.ValueString(), data.Url.ValueString(), bytes.NewBuffer(reqBody))
 	if err != nil {
 		resp.Diagnostics.AddError("HTTP Request Creation Failed", err.Error())
@@ -521,7 +577,7 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Add headers
-	applyRequestHeadersWithDefaults(request, data.Headers, r.providerMeta())
+	applyRequestHeadersWithWriteOnly(request, data.Headers, data.HeadersWo, r.providerMeta())
 
 	// Add query parameters
 	if !data.RequestParameters.IsNull() && !data.RequestParameters.IsUnknown() {
@@ -535,7 +591,7 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 	data.RequestUrlString = types.StringValue(request.URL.String())
 
-	tflog.Debug(ctx, fmt.Sprintf("Resource create API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, data.RequestBody.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("Resource create API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.RequestBody, data.RequestBodyWo, usedWriteOnlyBody)))
 	timeout := 10 * time.Second
 	if !data.Timeout.IsNull() {
 		timeout = time.Duration(data.Timeout.ValueInt64()) * time.Second
@@ -606,6 +662,11 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 	data.RequestUrlString = types.StringValue(request.URL.String())
 	setResourceResponseValues(&data, sanitizedResponse)
 	data.StatusCode = types.StringValue(strconv.Itoa(statusCode))
+	resp.Diagnostics.Append(snapshotWriteOnlyToPrivate(ctx, configModel, resp.Private)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	nullWriteOnlyAttributes(&data)
 	diags := resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -641,9 +702,10 @@ func (r *CurlResource) executeReadRequest(ctx context.Context, data CurlResource
 		return
 	}
 
-	var reqBody io.Reader = nil
-	if !data.ReadRequestBody.IsNull() && !data.ReadRequestBody.IsUnknown() {
-		reqBody = bytes.NewBuffer([]byte(data.ReadRequestBody.ValueString()))
+	var reqBody io.Reader
+	reqBodyBytes, usedWriteOnlyBody := resolveRequestBody(data.ReadRequestBody, data.ReadRequestBodyWo)
+	if len(reqBodyBytes) > 0 {
+		reqBody = bytes.NewBuffer(reqBodyBytes)
 	}
 
 	request, err := http.NewRequest(data.ReadMethod.ValueString(), data.ReadUrl.ValueString(), reqBody)
@@ -652,7 +714,7 @@ func (r *CurlResource) executeReadRequest(ctx context.Context, data CurlResource
 		return
 	}
 
-	applyRequestHeadersWithDefaults(request, data.ReadHeaders, r.providerMeta())
+	applyRequestHeadersWithWriteOnly(request, data.ReadHeaders, data.ReadHeadersWo, r.providerMeta())
 
 	if !data.ReadParameters.IsNull() && !data.ReadParameters.IsUnknown() {
 		params := request.URL.Query()
@@ -664,7 +726,7 @@ func (r *CurlResource) executeReadRequest(ctx context.Context, data CurlResource
 		request.URL.RawQuery = params.Encode()
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Resource read API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, data.ReadRequestBody.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("Resource read API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.ReadRequestBody, data.ReadRequestBodyWo, usedWriteOnlyBody)))
 
 	httpResp, err := client.Do(request)
 	if err != nil {
@@ -750,8 +812,14 @@ func (r *CurlResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	resp.Diagnostics.Append(loadWriteOnlyFromPrivate(ctx, req.Private, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if data.SkipRead.ValueBool() {
 		tflog.Debug(ctx, "Skipping Read() as skip_read is true")
+		resp.Private = req.Private
 		return
 	}
 
@@ -771,7 +839,9 @@ func (r *CurlResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		setResourceResponseValues(&data, result.SanitizedResponse)
 	}
 
+	nullWriteOnlyAttributes(&data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Private = req.Private
 }
 
 func (r *CurlResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -781,6 +851,11 @@ func (r *CurlResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 
 	var data CurlResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(loadWriteOnlyFromPrivate(ctx, req.Private, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -810,20 +885,32 @@ func (r *CurlResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 			"The read response does not match stored state. Terraform will replace this resource to reconcile configuration.",
 		)
 	}
+
+	resp.Private = req.Private
 }
 
 func (r *CurlResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data CurlResourceModel
+	var plan CurlResourceModel
+	var state CurlResourceModel
+	var config CurlResourceModel
 
-	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Private = req.Private
+	if writeOnlyVersionsChanged(state, config) {
+		resp.Diagnostics.Append(snapshotWriteOnlyToPrivate(ctx, config, resp.Private)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	nullWriteOnlyAttributes(&plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -831,6 +918,11 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	// Read prior state into model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(loadWriteOnlyFromPrivate(ctx, req.Private, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -867,9 +959,10 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	// Build Destroy Request
-	var reqBody io.Reader = nil
-	if !data.DestroyRequestBody.IsNull() && !data.DestroyRequestBody.IsUnknown() {
-		reqBody = bytes.NewBuffer([]byte(data.DestroyRequestBody.ValueString()))
+	var reqBody io.Reader
+	destroyBody, usedWriteOnlyBody := resolveRequestBody(data.DestroyRequestBody, data.DestroyRequestBodyWo)
+	if len(destroyBody) > 0 {
+		reqBody = bytes.NewBuffer(destroyBody)
 	}
 
 	request, err := http.NewRequest(data.DestroyMethod.ValueString(), data.DestroyUrl.ValueString(), reqBody)
@@ -879,7 +972,7 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	// Add Headers
-	applyRequestHeadersWithDefaults(request, data.DestroyHeaders, r.providerMeta())
+	applyRequestHeadersWithWriteOnly(request, data.DestroyHeaders, data.DestroyHeadersWo, r.providerMeta())
 
 	// Add Query Parameters
 	if !data.DestroyRequestParameters.IsNull() && !data.DestroyRequestParameters.IsUnknown() {
@@ -897,7 +990,7 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	retryInterval := time.Duration(data.DestroyRetryInterval.ValueInt64()) * time.Second
 	maxRetry := int(data.DestroyMaxRetry.ValueInt64())
 
-	tflog.Debug(ctx, fmt.Sprintf("Resource destroy API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, data.RequestBody.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("Resource destroy API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.DestroyRequestBody, data.DestroyRequestBodyWo, usedWriteOnlyBody)))
 
 	var bodyBytes []byte
 	var statusCode int
@@ -985,6 +1078,18 @@ func (r CurlResource) ConfigValidators(ctx context.Context) []resource.ConfigVal
 			path.MatchRoot("read_method"),
 			path.MatchRoot("read_response_codes"),
 		),
+		resourcevalidator.Conflicting(path.MatchRoot("headers"), path.MatchRoot("headers_wo")),
+		resourcevalidator.Conflicting(path.MatchRoot("request_body"), path.MatchRoot("request_body_wo")),
+		resourcevalidator.Conflicting(path.MatchRoot("read_headers"), path.MatchRoot("read_headers_wo")),
+		resourcevalidator.Conflicting(path.MatchRoot("read_request_body"), path.MatchRoot("read_request_body_wo")),
+		resourcevalidator.Conflicting(path.MatchRoot("destroy_headers"), path.MatchRoot("destroy_headers_wo")),
+		resourcevalidator.Conflicting(path.MatchRoot("destroy_request_body"), path.MatchRoot("destroy_request_body_wo")),
+		resourcevalidator.RequiredTogether(path.MatchRoot("headers_wo"), path.MatchRoot("headers_wo_version")),
+		resourcevalidator.RequiredTogether(path.MatchRoot("request_body_wo"), path.MatchRoot("request_body_wo_version")),
+		resourcevalidator.RequiredTogether(path.MatchRoot("read_headers_wo"), path.MatchRoot("read_headers_wo_version")),
+		resourcevalidator.RequiredTogether(path.MatchRoot("read_request_body_wo"), path.MatchRoot("read_request_body_wo_version")),
+		resourcevalidator.RequiredTogether(path.MatchRoot("destroy_headers_wo"), path.MatchRoot("destroy_headers_wo_version")),
+		resourcevalidator.RequiredTogether(path.MatchRoot("destroy_request_body_wo"), path.MatchRoot("destroy_request_body_wo_version")),
 	}
 }
 
@@ -1137,6 +1242,8 @@ func (r *CurlResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 				oldState.ReadCaCertDirectory = types.StringNull()
 				oldState.ReadSkipTlsVerify = types.BoolNull()
 				oldState.ReadResponseCodes = types.ListNull(types.StringType)
+
+				nullWriteOnlyAttributes(&oldState)
 
 				// Set the upgraded state
 				diags = resp.State.Set(ctx, oldState)

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -591,7 +591,7 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 	data.RequestUrlString = types.StringValue(request.URL.String())
 
-	tflog.Debug(ctx, fmt.Sprintf("Resource create API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.RequestBody, data.RequestBodyWo, usedWriteOnlyBody)))
+	tflog.Debug(ctx, fmt.Sprintf("Resource create API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.RequestBody, usedWriteOnlyBody)))
 	timeout := 10 * time.Second
 	if !data.Timeout.IsNull() {
 		timeout = time.Duration(data.Timeout.ValueInt64()) * time.Second
@@ -726,7 +726,7 @@ func (r *CurlResource) executeReadRequest(ctx context.Context, data CurlResource
 		request.URL.RawQuery = params.Encode()
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Resource read API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.ReadRequestBody, data.ReadRequestBodyWo, usedWriteOnlyBody)))
+	tflog.Debug(ctx, fmt.Sprintf("Resource read API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.ReadRequestBody, usedWriteOnlyBody)))
 
 	httpResp, err := client.Do(request)
 	if err != nil {
@@ -990,7 +990,7 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	retryInterval := time.Duration(data.DestroyRetryInterval.ValueInt64()) * time.Second
 	maxRetry := int(data.DestroyMaxRetry.ValueInt64())
 
-	tflog.Debug(ctx, fmt.Sprintf("Resource destroy API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.DestroyRequestBody, data.DestroyRequestBodyWo, usedWriteOnlyBody)))
+	tflog.Debug(ctx, fmt.Sprintf("Resource destroy API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.DestroyRequestBody, usedWriteOnlyBody)))
 
 	var bodyBytes []byte
 	var statusCode int

--- a/internal/provider/curl_resource_test.go
+++ b/internal/provider/curl_resource_test.go
@@ -1019,64 +1019,76 @@ func TestCurlResource_StateUpgrade(t *testing.T) {
 	// Define the complete schema
 	schemaVar := schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id":                     schema.StringAttribute{Computed: true},
-			"name":                   schema.StringAttribute{Optional: true},
-			"url":                    schema.StringAttribute{Required: true},
-			"method":                 schema.StringAttribute{Optional: true},
-			"headers":                schema.MapAttribute{ElementType: types.StringType, Optional: true},
-			"request_parameters":     schema.MapAttribute{ElementType: types.StringType, Optional: true},
-			"request_body":           schema.StringAttribute{Optional: true},
-			"cert_file":              schema.StringAttribute{Optional: true},
-			"key_file":               schema.StringAttribute{Optional: true},
-			"ca_cert_file":           schema.StringAttribute{Optional: true},
-			"ca_cert_directory":      schema.StringAttribute{Optional: true},
-			"skip_tls_verify":        schema.BoolAttribute{Optional: true},
-			"digest_auth":            resourceDigestAuthSchema(""),
-			"timeout":                schema.Int64Attribute{Optional: true},
-			"response_codes":         schema.ListAttribute{ElementType: types.StringType, Optional: true},
-			"status_code":            schema.StringAttribute{Computed: true},
-			"response":               schema.StringAttribute{Computed: true},
-			"sensitive_response":     schema.StringAttribute{Computed: true, Sensitive: true},
-			"response_sensitive":     schema.BoolAttribute{Optional: true, Computed: true},
-			"request_url_string":     schema.StringAttribute{Computed: true},
-			"max_retry":              schema.Int64Attribute{Optional: true},
-			"retry_interval":         schema.Int64Attribute{Optional: true},
-			"ignore_response_fields": schema.ListAttribute{ElementType: types.StringType, Optional: true},
-			"drift_marker":           schema.StringAttribute{Optional: true},
+			"id":                      schema.StringAttribute{Computed: true},
+			"name":                    schema.StringAttribute{Optional: true},
+			"url":                     schema.StringAttribute{Required: true},
+			"method":                  schema.StringAttribute{Optional: true},
+			"headers":                 schema.MapAttribute{ElementType: types.StringType, Optional: true},
+			"headers_wo":              writeOnlyHeadersSchema(""),
+			"headers_wo_version":      writeOnlyVersionSchema(""),
+			"request_body_wo":         writeOnlyBodySchema(""),
+			"request_body_wo_version": writeOnlyVersionSchema(""),
+			"request_parameters":      schema.MapAttribute{ElementType: types.StringType, Optional: true},
+			"request_body":            schema.StringAttribute{Optional: true},
+			"cert_file":               schema.StringAttribute{Optional: true},
+			"key_file":                schema.StringAttribute{Optional: true},
+			"ca_cert_file":            schema.StringAttribute{Optional: true},
+			"ca_cert_directory":       schema.StringAttribute{Optional: true},
+			"skip_tls_verify":         schema.BoolAttribute{Optional: true},
+			"digest_auth":             resourceDigestAuthSchema(""),
+			"timeout":                 schema.Int64Attribute{Optional: true},
+			"response_codes":          schema.ListAttribute{ElementType: types.StringType, Optional: true},
+			"status_code":             schema.StringAttribute{Computed: true},
+			"response":                schema.StringAttribute{Computed: true},
+			"sensitive_response":      schema.StringAttribute{Computed: true, Sensitive: true},
+			"response_sensitive":      schema.BoolAttribute{Optional: true, Computed: true},
+			"request_url_string":      schema.StringAttribute{Computed: true},
+			"max_retry":               schema.Int64Attribute{Optional: true},
+			"retry_interval":          schema.Int64Attribute{Optional: true},
+			"ignore_response_fields":  schema.ListAttribute{ElementType: types.StringType, Optional: true},
+			"drift_marker":            schema.StringAttribute{Optional: true},
 
 			// Read-related fields
-			"skip_read":              schema.BoolAttribute{Optional: true},
-			"read_url":               schema.StringAttribute{Optional: true},
-			"read_method":            schema.StringAttribute{Optional: true},
-			"read_headers":           schema.MapAttribute{ElementType: types.StringType, Optional: true},
-			"read_parameters":        schema.MapAttribute{ElementType: types.StringType, Optional: true},
-			"read_request_body":      schema.StringAttribute{Optional: true},
-			"read_cert_file":         schema.StringAttribute{Optional: true},
-			"read_key_file":          schema.StringAttribute{Optional: true},
-			"read_ca_cert_file":      schema.StringAttribute{Optional: true},
-			"read_ca_cert_directory": schema.StringAttribute{Optional: true},
-			"read_skip_tls_verify":   schema.BoolAttribute{Optional: true},
-			"read_digest_auth":       resourceDigestAuthSchema(""),
-			"read_response_codes":    schema.ListAttribute{ElementType: types.StringType, Optional: true},
+			"skip_read":                    schema.BoolAttribute{Optional: true},
+			"read_url":                     schema.StringAttribute{Optional: true},
+			"read_method":                  schema.StringAttribute{Optional: true},
+			"read_headers":                 schema.MapAttribute{ElementType: types.StringType, Optional: true},
+			"read_headers_wo":              writeOnlyHeadersSchema(""),
+			"read_headers_wo_version":      writeOnlyVersionSchema(""),
+			"read_request_body_wo":         writeOnlyBodySchema(""),
+			"read_request_body_wo_version": writeOnlyVersionSchema(""),
+			"read_parameters":              schema.MapAttribute{ElementType: types.StringType, Optional: true},
+			"read_request_body":            schema.StringAttribute{Optional: true},
+			"read_cert_file":               schema.StringAttribute{Optional: true},
+			"read_key_file":                schema.StringAttribute{Optional: true},
+			"read_ca_cert_file":            schema.StringAttribute{Optional: true},
+			"read_ca_cert_directory":       schema.StringAttribute{Optional: true},
+			"read_skip_tls_verify":         schema.BoolAttribute{Optional: true},
+			"read_digest_auth":             resourceDigestAuthSchema(""),
+			"read_response_codes":          schema.ListAttribute{ElementType: types.StringType, Optional: true},
 
 			// Destroy-related fields
-			"skip_destroy":               schema.BoolAttribute{Optional: true},
-			"destroy_url":                schema.StringAttribute{Optional: true},
-			"destroy_method":             schema.StringAttribute{Optional: true},
-			"destroy_headers":            schema.MapAttribute{ElementType: types.StringType, Optional: true},
-			"destroy_request_parameters": schema.MapAttribute{ElementType: types.StringType, Optional: true},
-			"destroy_request_body":       schema.StringAttribute{Optional: true},
-			"destroy_cert_file":          schema.StringAttribute{Optional: true},
-			"destroy_key_file":           schema.StringAttribute{Optional: true},
-			"destroy_ca_cert_file":       schema.StringAttribute{Optional: true},
-			"destroy_ca_cert_directory":  schema.StringAttribute{Optional: true},
-			"destroy_skip_tls_verify":    schema.BoolAttribute{Optional: true},
-			"destroy_digest_auth":        resourceDigestAuthSchema(""),
-			"destroy_response_codes":     schema.ListAttribute{ElementType: types.StringType, Optional: true},
-			"destroy_timeout":            schema.Int64Attribute{Optional: true},
-			"destroy_max_retry":          schema.Int64Attribute{Optional: true},
-			"destroy_retry_interval":     schema.Int64Attribute{Optional: true},
-			"destroy_request_url_string": schema.StringAttribute{Computed: true},
+			"skip_destroy":                    schema.BoolAttribute{Optional: true},
+			"destroy_url":                     schema.StringAttribute{Optional: true},
+			"destroy_method":                  schema.StringAttribute{Optional: true},
+			"destroy_headers":                 schema.MapAttribute{ElementType: types.StringType, Optional: true},
+			"destroy_headers_wo":              writeOnlyHeadersSchema(""),
+			"destroy_headers_wo_version":      writeOnlyVersionSchema(""),
+			"destroy_request_body_wo":         writeOnlyBodySchema(""),
+			"destroy_request_body_wo_version": writeOnlyVersionSchema(""),
+			"destroy_request_parameters":      schema.MapAttribute{ElementType: types.StringType, Optional: true},
+			"destroy_request_body":            schema.StringAttribute{Optional: true},
+			"destroy_cert_file":               schema.StringAttribute{Optional: true},
+			"destroy_key_file":                schema.StringAttribute{Optional: true},
+			"destroy_ca_cert_file":            schema.StringAttribute{Optional: true},
+			"destroy_ca_cert_directory":       schema.StringAttribute{Optional: true},
+			"destroy_skip_tls_verify":         schema.BoolAttribute{Optional: true},
+			"destroy_digest_auth":             resourceDigestAuthSchema(""),
+			"destroy_response_codes":          schema.ListAttribute{ElementType: types.StringType, Optional: true},
+			"destroy_timeout":                 schema.Int64Attribute{Optional: true},
+			"destroy_max_retry":               schema.Int64Attribute{Optional: true},
+			"destroy_retry_interval":          schema.Int64Attribute{Optional: true},
+			"destroy_request_url_string":      schema.StringAttribute{Computed: true},
 		},
 	}
 
@@ -1107,6 +1119,7 @@ func TestCurlResource_StateUpgrade(t *testing.T) {
 	state := tfsdk.State{
 		Schema: schemaVar,
 	}
+	nullWriteOnlyAttributes(oldState)
 	diags := state.Set(ctx, oldState)
 	if diags.HasError() {
 		t.Fatalf("error setting initial state: %v", diags)
@@ -1401,6 +1414,7 @@ func TestCurlResource_Read_ResponseSensitiveToggle(t *testing.T) {
 	}
 
 	state1 := tfsdk.State{Schema: schemaResp.Schema}
+	nullWriteOnlyAttributes(&initialState)
 	diags := state1.Set(ctx, &initialState)
 	if diags.HasError() {
 		t.Fatalf("Failed to set initial state: %v", diags)
@@ -1426,6 +1440,7 @@ func TestCurlResource_Read_ResponseSensitiveToggle(t *testing.T) {
 
 	stateWithToggle := initialState
 	stateWithToggle.DriftMarker = types.StringValue("initial")
+	nullWriteOnlyAttributes(&stateWithToggle)
 
 	state2 := tfsdk.State{Schema: schemaResp.Schema}
 	diags = state2.Set(ctx, &stateWithToggle)
@@ -1481,6 +1496,7 @@ func TestCurlResource_Read_ResponseSensitiveToggle(t *testing.T) {
 	}
 
 	state3 := tfsdk.State{Schema: schemaResp.Schema}
+	nullWriteOnlyAttributes(&stateWithReverseToggle)
 	diags = state3.Set(ctx, &stateWithReverseToggle)
 	if diags.HasError() {
 		t.Fatalf("Failed to set state with reverse toggle: %v", diags)
@@ -1575,6 +1591,7 @@ func TestCurlResource_ModifyPlan_ReadDrift(t *testing.T) {
 	}
 
 	state := tfsdk.State{Schema: schemaResp.Schema}
+	nullWriteOnlyAttributes(&stateModel)
 	if diags := state.Set(ctx, &stateModel); diags.HasError() {
 		t.Fatalf("failed to set state: %v", diags)
 	}
@@ -1646,6 +1663,7 @@ func TestCurlResource_ModifyPlan_BadReadStatusCode(t *testing.T) {
 	}
 
 	state := tfsdk.State{Schema: schemaResp.Schema}
+	nullWriteOnlyAttributes(&stateModel)
 	if diags := state.Set(ctx, &stateModel); diags.HasError() {
 		t.Fatalf("failed to set state: %v", diags)
 	}
@@ -1951,6 +1969,7 @@ func TestCurlResource_Delete_ProviderDefaultHeadersOverridesStaleState(t *testin
 	}
 
 	state := tfsdk.State{Schema: schemaResp.Schema}
+	nullWriteOnlyAttributes(&stateModel)
 	if diags := state.Set(ctx, &stateModel); diags.HasError() {
 		t.Fatalf("failed to set state: %v", diags)
 	}

--- a/internal/provider/digest_auth_test.go
+++ b/internal/provider/digest_auth_test.go
@@ -157,6 +157,7 @@ func TestCurlResource_Delete_ProviderDefaultDigestAuth(t *testing.T) {
 	}
 
 	state := tfsdk.State{Schema: schemaResp.Schema}
+	nullWriteOnlyAttributes(&stateModel)
 	if diags := state.Set(ctx, &stateModel); diags.HasError() {
 		t.Fatalf("failed to set state: %v", diags)
 	}

--- a/internal/provider/write_only.go
+++ b/internal/provider/write_only.go
@@ -1,0 +1,228 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const writeOnlyPrivateStateKey = "write_only_snapshot"
+
+type writeOnlyPrivateSnapshot struct {
+	HeadersCreate  map[string]string `json:"headers_create,omitempty"`
+	HeadersRead    map[string]string `json:"headers_read,omitempty"`
+	HeadersDestroy map[string]string `json:"headers_destroy,omitempty"`
+	BodyCreate     string            `json:"body_create,omitempty"`
+	BodyRead       string            `json:"body_read,omitempty"`
+	BodyDestroy    string            `json:"body_destroy,omitempty"`
+}
+
+type privateStateWriter interface {
+	SetKey(context.Context, string, []byte) diag.Diagnostics
+}
+
+type privateStateReader interface {
+	GetKey(context.Context, string) ([]byte, diag.Diagnostics)
+}
+
+func mapHasValues(m types.Map) bool {
+	if m.IsNull() || m.IsUnknown() {
+		return false
+	}
+	return len(m.Elements()) > 0
+}
+
+func mapToStringMap(m types.Map) map[string]string {
+	if !mapHasValues(m) {
+		return nil
+	}
+	result := make(map[string]string, len(m.Elements()))
+	for k, v := range m.Elements() {
+		if strVal, ok := v.(types.String); ok {
+			result[k] = strVal.ValueString()
+		}
+	}
+	return result
+}
+
+func stringMapToTypesMap(values map[string]string) types.Map {
+	if len(values) == 0 {
+		return types.MapNull(types.StringType)
+	}
+	result := make(map[string]types.String, len(values))
+	for k, v := range values {
+		result[k] = types.StringValue(v)
+	}
+	tfMap, diags := types.MapValueFrom(context.Background(), types.StringType, result)
+	if diags.HasError() {
+		return types.MapNull(types.StringType)
+	}
+	return tfMap
+}
+
+func resolveRequestBody(regular, writeOnly types.String) ([]byte, bool) {
+	if hasValue(writeOnly) {
+		return []byte(writeOnly.ValueString()), true
+	}
+	if hasValue(regular) {
+		return []byte(regular.ValueString()), false
+	}
+	return nil, false
+}
+
+func applyRequestHeadersWithWriteOnly(req *http.Request, headers, headersWo types.Map, meta *ProviderMeta) {
+	applyRequestHeaders(req, headers)
+	if meta != nil {
+		for k, v := range meta.DefaultHeaders() {
+			setRequestHeader(req, k, v)
+		}
+	}
+	applyRequestHeaders(req, headersWo)
+}
+
+func requestBodyForLog(regular, writeOnly types.String, usedWriteOnly bool) string {
+	if usedWriteOnly {
+		return "<redacted write-only request body>"
+	}
+	if hasValue(regular) {
+		return regular.ValueString()
+	}
+	return ""
+}
+
+func snapshotFromConfig(config CurlResourceModel) writeOnlyPrivateSnapshot {
+	return writeOnlyPrivateSnapshot{
+		HeadersCreate:  mapToStringMap(config.HeadersWo),
+		HeadersRead:    mapToStringMap(config.ReadHeadersWo),
+		HeadersDestroy: mapToStringMap(config.DestroyHeadersWo),
+		BodyCreate:     config.RequestBodyWo.ValueString(),
+		BodyRead:       config.ReadRequestBodyWo.ValueString(),
+		BodyDestroy:    config.DestroyRequestBodyWo.ValueString(),
+	}
+}
+
+func snapshotWriteOnlyToPrivate(ctx context.Context, config CurlResourceModel, private privateStateWriter) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if private == nil {
+		return diags
+	}
+
+	snapshot := snapshotFromConfig(config)
+	var raw []byte
+	var err error
+	if !snapshot.isEmpty() {
+		raw, err = json.Marshal(snapshot)
+		if err != nil {
+			diags.AddError("Write-Only Snapshot Error", fmt.Sprintf("Failed to marshal write-only snapshot: %s", err))
+			return diags
+		}
+	}
+
+	diags.Append(private.SetKey(ctx, writeOnlyPrivateStateKey, raw)...)
+	return diags
+}
+
+func loadWriteOnlyFromPrivate(ctx context.Context, private privateStateReader, data *CurlResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if private == nil || data == nil {
+		return diags
+	}
+
+	raw, getDiags := private.GetKey(ctx, writeOnlyPrivateStateKey)
+	diags.Append(getDiags...)
+	if diags.HasError() || raw == nil {
+		return diags
+	}
+
+	var snapshot writeOnlyPrivateSnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		diags.AddError("Write-Only Snapshot Error", fmt.Sprintf("Failed to unmarshal write-only snapshot: %s", err))
+		return diags
+	}
+
+	data.HeadersWo = stringMapToTypesMap(snapshot.HeadersCreate)
+	data.ReadHeadersWo = stringMapToTypesMap(snapshot.HeadersRead)
+	data.DestroyHeadersWo = stringMapToTypesMap(snapshot.HeadersDestroy)
+
+	if snapshot.BodyCreate != "" {
+		data.RequestBodyWo = types.StringValue(snapshot.BodyCreate)
+	}
+	if snapshot.BodyRead != "" {
+		data.ReadRequestBodyWo = types.StringValue(snapshot.BodyRead)
+	}
+	if snapshot.BodyDestroy != "" {
+		data.DestroyRequestBodyWo = types.StringValue(snapshot.BodyDestroy)
+	}
+
+	return diags
+}
+
+func mergeWriteOnlyFromConfig(ctx context.Context, config tfsdk.Config, data *CurlResourceModel) diag.Diagnostics {
+	var configModel CurlResourceModel
+	diags := config.Get(ctx, &configModel)
+	if diags.HasError() || data == nil {
+		return diags
+	}
+
+	data.HeadersWo = configModel.HeadersWo
+	data.RequestBodyWo = configModel.RequestBodyWo
+	data.ReadHeadersWo = configModel.ReadHeadersWo
+	data.ReadRequestBodyWo = configModel.ReadRequestBodyWo
+	data.DestroyHeadersWo = configModel.DestroyHeadersWo
+	data.DestroyRequestBodyWo = configModel.DestroyRequestBodyWo
+
+	return diags
+}
+
+func (s writeOnlyPrivateSnapshot) isEmpty() bool {
+	return len(s.HeadersCreate) == 0 &&
+		len(s.HeadersRead) == 0 &&
+		len(s.HeadersDestroy) == 0 &&
+		s.BodyCreate == "" &&
+		s.BodyRead == "" &&
+		s.BodyDestroy == ""
+}
+
+func writeOnlyVersionsChanged(state, config CurlResourceModel) bool {
+	return state.HeadersWoVersion.ValueInt64() != config.HeadersWoVersion.ValueInt64() ||
+		state.RequestBodyWoVersion.ValueInt64() != config.RequestBodyWoVersion.ValueInt64() ||
+		state.ReadHeadersWoVersion.ValueInt64() != config.ReadHeadersWoVersion.ValueInt64() ||
+		state.ReadRequestBodyWoVersion.ValueInt64() != config.ReadRequestBodyWoVersion.ValueInt64() ||
+		state.DestroyHeadersWoVersion.ValueInt64() != config.DestroyHeadersWoVersion.ValueInt64() ||
+		state.DestroyRequestBodyWoVersion.ValueInt64() != config.DestroyRequestBodyWoVersion.ValueInt64()
+}
+
+func applyWriteOnlySnapshot(snapshot writeOnlyPrivateSnapshot, data *CurlResourceModel) {
+	if data == nil {
+		return
+	}
+	data.HeadersWo = stringMapToTypesMap(snapshot.HeadersCreate)
+	data.ReadHeadersWo = stringMapToTypesMap(snapshot.HeadersRead)
+	data.DestroyHeadersWo = stringMapToTypesMap(snapshot.HeadersDestroy)
+	if snapshot.BodyCreate != "" {
+		data.RequestBodyWo = types.StringValue(snapshot.BodyCreate)
+	}
+	if snapshot.BodyRead != "" {
+		data.ReadRequestBodyWo = types.StringValue(snapshot.BodyRead)
+	}
+	if snapshot.BodyDestroy != "" {
+		data.DestroyRequestBodyWo = types.StringValue(snapshot.BodyDestroy)
+	}
+}
+
+func nullWriteOnlyAttributes(data *CurlResourceModel) {
+	if data == nil {
+		return
+	}
+	data.HeadersWo = types.MapNull(types.StringType)
+	data.RequestBodyWo = types.StringNull()
+	data.ReadHeadersWo = types.MapNull(types.StringType)
+	data.ReadRequestBodyWo = types.StringNull()
+	data.DestroyHeadersWo = types.MapNull(types.StringType)
+	data.DestroyRequestBodyWo = types.StringNull()
+}

--- a/internal/provider/write_only.go
+++ b/internal/provider/write_only.go
@@ -85,7 +85,7 @@ func applyRequestHeadersWithWriteOnly(req *http.Request, headers, headersWo type
 	applyRequestHeaders(req, headersWo)
 }
 
-func requestBodyForLog(regular, writeOnly types.String, usedWriteOnly bool) string {
+func requestBodyForLog(regular types.String, usedWriteOnly bool) string {
 	if usedWriteOnly {
 		return "<redacted write-only request body>"
 	}
@@ -195,24 +195,6 @@ func writeOnlyVersionsChanged(state, config CurlResourceModel) bool {
 		state.ReadRequestBodyWoVersion.ValueInt64() != config.ReadRequestBodyWoVersion.ValueInt64() ||
 		state.DestroyHeadersWoVersion.ValueInt64() != config.DestroyHeadersWoVersion.ValueInt64() ||
 		state.DestroyRequestBodyWoVersion.ValueInt64() != config.DestroyRequestBodyWoVersion.ValueInt64()
-}
-
-func applyWriteOnlySnapshot(snapshot writeOnlyPrivateSnapshot, data *CurlResourceModel) {
-	if data == nil {
-		return
-	}
-	data.HeadersWo = stringMapToTypesMap(snapshot.HeadersCreate)
-	data.ReadHeadersWo = stringMapToTypesMap(snapshot.HeadersRead)
-	data.DestroyHeadersWo = stringMapToTypesMap(snapshot.HeadersDestroy)
-	if snapshot.BodyCreate != "" {
-		data.RequestBodyWo = types.StringValue(snapshot.BodyCreate)
-	}
-	if snapshot.BodyRead != "" {
-		data.ReadRequestBodyWo = types.StringValue(snapshot.BodyRead)
-	}
-	if snapshot.BodyDestroy != "" {
-		data.DestroyRequestBodyWo = types.StringValue(snapshot.BodyDestroy)
-	}
 }
 
 func nullWriteOnlyAttributes(data *CurlResourceModel) {

--- a/internal/provider/write_only_schema.go
+++ b/internal/provider/write_only_schema.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func writeOnlyHeadersSchema(markdown string) schema.MapAttribute {
+	return schema.MapAttribute{
+		ElementType:         types.StringType,
+		Optional:            true,
+		Sensitive:           true,
+		WriteOnly:           true,
+		MarkdownDescription: markdown,
+	}
+}
+
+func writeOnlyBodySchema(markdown string) schema.StringAttribute {
+	return schema.StringAttribute{
+		Optional:            true,
+		Sensitive:           true,
+		WriteOnly:           true,
+		MarkdownDescription: markdown,
+	}
+}
+
+func writeOnlyVersionSchema(markdown string) schema.Int64Attribute {
+	return schema.Int64Attribute{
+		Optional:            true,
+		Computed:            true,
+		MarkdownDescription: markdown,
+		Default:             int64default.StaticInt64(0),
+	}
+}

--- a/internal/provider/write_only_test.go
+++ b/internal/provider/write_only_test.go
@@ -1,0 +1,156 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type fakePrivateState struct {
+	data map[string][]byte
+}
+
+func (f *fakePrivateState) GetKey(_ context.Context, key string) ([]byte, diag.Diagnostics) {
+	if f.data == nil {
+		return nil, nil
+	}
+	return f.data[key], nil
+}
+
+func (f *fakePrivateState) SetKey(_ context.Context, key string, value []byte) diag.Diagnostics {
+	if f.data == nil {
+		f.data = make(map[string][]byte)
+	}
+	if len(value) == 0 {
+		delete(f.data, key)
+		return nil
+	}
+	f.data[key] = value
+	return nil
+}
+
+func TestResolveRequestBodyPrefersWriteOnly(t *testing.T) {
+	regular := types.StringValue(`{"stored":true}`)
+	writeOnly := types.StringValue(`{"secret":true}`)
+
+	body, usedWo := resolveRequestBody(regular, writeOnly)
+	if !usedWo || string(body) != `{"secret":true}` {
+		t.Fatalf("expected write-only body, got %q usedWo=%v", body, usedWo)
+	}
+}
+
+func TestResolveRequestBodyUsesRegularWhenWriteOnlyUnset(t *testing.T) {
+	regular := types.StringValue(`{"stored":true}`)
+	body, usedWo := resolveRequestBody(regular, types.StringNull())
+	if usedWo || string(body) != `{"stored":true}` {
+		t.Fatalf("expected regular body, got %q usedWo=%v", body, usedWo)
+	}
+}
+
+func TestApplyRequestHeadersWithWriteOnlyOverridesDefaults(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	headers := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"X-Resource": types.StringValue("resource"),
+	})
+	headersWo := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"Authorization": types.StringValue("Bearer write-only"),
+		"X-Resource":    types.StringValue("override"),
+	})
+	meta := NewProviderMeta(
+		types.StringNull(),
+		types.StringNull(),
+		types.StringNull(),
+		types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Authorization": types.StringValue("Bearer provider"),
+		}),
+		nil,
+	)
+
+	applyRequestHeadersWithWriteOnly(req, headers, headersWo, meta)
+
+	if got := req.Header.Get("Authorization"); got != "Bearer write-only" {
+		t.Fatalf("expected write-only Authorization, got %q", got)
+	}
+	if got := req.Header.Get("X-Resource"); got != "override" {
+		t.Fatalf("expected write-only header override, got %q", got)
+	}
+}
+
+func TestWriteOnlyPrivateSnapshotRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	private := &fakePrivateState{}
+	config := CurlResourceModel{
+		HeadersWo: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Authorization": types.StringValue("Bearer create"),
+		}),
+		ReadHeadersWo: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Authorization": types.StringValue("Bearer read"),
+		}),
+		DestroyHeadersWo: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Authorization": types.StringValue("Bearer destroy"),
+		}),
+		RequestBodyWo:        types.StringValue(`{"create":true}`),
+		ReadRequestBodyWo:    types.StringValue(`{"read":true}`),
+		DestroyRequestBodyWo: types.StringValue(`{"destroy":true}`),
+	}
+
+	if diags := snapshotWriteOnlyToPrivate(ctx, config, private); diags.HasError() {
+		t.Fatalf("snapshot failed: %v", diags)
+	}
+
+	var loaded CurlResourceModel
+	if diags := loadWriteOnlyFromPrivate(ctx, private, &loaded); diags.HasError() {
+		t.Fatalf("load failed: %v", diags)
+	}
+
+	if loaded.DestroyHeadersWo.Elements()["Authorization"].(types.String).ValueString() != "Bearer destroy" {
+		t.Fatalf("unexpected destroy headers %#v", loaded.DestroyHeadersWo)
+	}
+	if loaded.ReadRequestBodyWo.ValueString() != `{"read":true}` {
+		t.Fatalf("unexpected read body %q", loaded.ReadRequestBodyWo.ValueString())
+	}
+}
+
+func TestDestroyWriteOnlyLoadedFromPrivateStateAppliedToRequest(t *testing.T) {
+	ctx := context.Background()
+	private := &fakePrivateState{}
+	config := CurlResourceModel{
+		DestroyHeadersWo: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Authorization": types.StringValue("Bearer destroy-secret"),
+		}),
+	}
+	if diags := snapshotWriteOnlyToPrivate(ctx, config, private); diags.HasError() {
+		t.Fatalf("snapshot failed: %v", diags)
+	}
+
+	var data CurlResourceModel
+	if diags := loadWriteOnlyFromPrivate(ctx, private, &data); diags.HasError() {
+		t.Fatalf("load failed: %v", diags)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "https://example.com/destroy", nil)
+	applyRequestHeadersWithWriteOnly(req, types.MapNull(types.StringType), data.DestroyHeadersWo, nil)
+	if got := req.Header.Get("Authorization"); got != "Bearer destroy-secret" {
+		t.Fatalf("expected destroy write-only header on request, got %q", got)
+	}
+}
+
+func TestWriteOnlyVersionsChanged(t *testing.T) {
+	state := CurlResourceModel{HeadersWoVersion: types.Int64Value(1)}
+	config := CurlResourceModel{HeadersWoVersion: types.Int64Value(2)}
+	if !writeOnlyVersionsChanged(state, config) {
+		t.Fatal("expected version change to be detected")
+	}
+}
+
+func TestRequestBodyForLogRedactsWriteOnly(t *testing.T) {
+	got := requestBodyForLog(types.StringNull(), types.StringValue("secret"), true)
+	if got != "<redacted write-only request body>" {
+		t.Fatalf("unexpected log value %q", got)
+	}
+}

--- a/internal/provider/write_only_test.go
+++ b/internal/provider/write_only_test.go
@@ -108,7 +108,8 @@ func TestWriteOnlyPrivateSnapshotRoundtrip(t *testing.T) {
 		t.Fatalf("load failed: %v", diags)
 	}
 
-	if loaded.DestroyHeadersWo.Elements()["Authorization"].(types.String).ValueString() != "Bearer destroy" {
+	auth, ok := loaded.DestroyHeadersWo.Elements()["Authorization"].(types.String)
+	if !ok || auth.ValueString() != "Bearer destroy" {
 		t.Fatalf("unexpected destroy headers %#v", loaded.DestroyHeadersWo)
 	}
 	if loaded.ReadRequestBodyWo.ValueString() != `{"read":true}` {
@@ -149,7 +150,7 @@ func TestWriteOnlyVersionsChanged(t *testing.T) {
 }
 
 func TestRequestBodyForLogRedactsWriteOnly(t *testing.T) {
-	got := requestBodyForLog(types.StringNull(), types.StringValue("secret"), true)
+	got := requestBodyForLog(types.StringNull(), true)
 	if got != "<redacted write-only request body>" {
 		t.Fatalf("unexpected log value %q", got)
 	}

--- a/templates/guides/default_headers.md.tmpl
+++ b/templates/guides/default_headers.md.tmpl
@@ -80,7 +80,7 @@ Provider headers win on key collision. This ensures a fresh provider token repla
 ## Limitations
 
 - Tokens set only in resource `headers` or `destroy_headers` are still persisted in state. For destroy-only refresh, move auth to `default_headers` or run `terraform apply` before destroy to update state.
-- Write-only resource headers (see issue #115) are a separate follow-up to avoid persisting secrets in state entirely.
+- Write-only resource headers (see the [Write-Only Headers and Request Bodies guide](write_only)) avoid persisting secrets in state entirely.
 - `default_headers` is marked sensitive in the provider schema and will not appear in plan output.
 
 ## Workaround without default_headers

--- a/templates/guides/digest_auth.md.tmpl
+++ b/templates/guides/digest_auth.md.tmpl
@@ -87,7 +87,7 @@ If credentials are set only in `destroy_digest_auth`, those values are persisted
 
 - HTTP Basic authentication is not built in; set a static `Authorization: Basic ...` header manually or use provider `default_headers`.
 - NTLM, Kerberos, and other enterprise proxy authentication mechanisms remain unsupported. See the [HTTP Proxy Support guide](proxy).
-- Digest credentials configured on resources are stored in Terraform state (marked sensitive). Write-only credentials are tracked separately in issue #115.
+- Digest credentials configured on resources are stored in Terraform state (marked sensitive). For credentials that must not appear in state, use write-only headers or provider `default_headers` where applicable. See the [Write-Only Headers and Request Bodies guide](write_only).
 - Custom `realm` or algorithm tuning is not exposed unless a real API requires it.
 
 ## Digest vs default_headers

--- a/templates/guides/write_only.md.tmpl
+++ b/templates/guides/write_only.md.tmpl
@@ -1,0 +1,82 @@
+---
+page_title: "Write-Only Headers and Request Bodies"
+subcategory: "Guides"
+description: |-
+  Use write-only headers and request bodies on terracurl_request resources to send secrets without persisting them in Terraform state.
+---
+
+# Write-Only Headers and Request Bodies
+
+Terraform 1.11+ supports **write-only arguments**: values supplied in configuration that are used during apply but are **not stored in plan or state JSON**. TerraCurl exposes this for `terracurl_request` resource headers and request bodies on create, read, and destroy operations.
+
+Use write-only attributes when secrets must not appear in `terraform show`, remote state, or version control–backed state files — even when marked `sensitive`.
+
+## Requirements
+
+- Terraform **1.11 or later**
+- `terracurl_request` **resource only** (write-only is not available on data sources, actions, or ephemeral resources)
+
+## Create example
+
+```terraform
+resource "terracurl_request" "example" {
+  name   = "example"
+  url    = "https://api.example.com/resource"
+  method = "PUT"
+
+  headers_wo = {
+    X-Vault-Token = var.vault_token
+  }
+  headers_wo_version = 1
+
+  request_body_wo = jsonencode({
+    password = var.password
+  })
+  request_body_wo_version = 1
+
+  response_codes = [200]
+  skip_read      = true
+}
+```
+
+Do **not** set both `headers` and `headers_wo` (or `request_body` and `request_body_wo`) on the same operation. TerraCurl rejects conflicting pairs at plan time.
+
+## Per-operation attributes
+
+| Operation | Headers | Body | Version attributes |
+|-----------|---------|------|--------------------|
+| Create | `headers_wo` | `request_body_wo` | `headers_wo_version`, `request_body_wo_version` |
+| Read | `read_headers_wo` | `read_request_body_wo` | `read_headers_wo_version`, `read_request_body_wo_version` |
+| Destroy | `destroy_headers_wo` | `destroy_request_body_wo` | `destroy_headers_wo_version`, `destroy_request_body_wo_version` |
+
+Version attributes are stored in state (not write-only). Increment a `_wo_version` when you change the corresponding write-only value so TerraCurl refreshes the snapshotted credentials on update.
+
+## Read and destroy without config access
+
+Terraform does not pass resource configuration to Read or Delete RPCs. TerraCurl **snapshots** read/destroy write-only values into provider private state during Create (and refreshes the snapshot on Update when a `_wo_version` changes). Private state is not shown in plan output, but it is persisted with the resource.
+
+For rotating destroy credentials without storing them in resource state, consider [provider `default_headers`](default_headers) instead.
+
+## Updating write-only values
+
+TerraCurl does not re-issue the create HTTP call on in-place update. To change a write-only body or header after initial apply:
+
+1. Update the write-only value in configuration
+2. Increment the matching `_wo_version` attribute
+3. Run `terraform apply`
+
+If the API must be called again with the new payload, trigger replacement through other attribute changes or taint the resource.
+
+## Comparison with other options
+
+| Approach | In state? | In plan? | Destroy refresh |
+|----------|-----------|----------|-----------------|
+| `headers` / `request_body` | Yes (sensitive still stored) | Hidden if sensitive | From state (can go stale) |
+| `headers_wo` / `request_body_wo` | No | No | From private snapshot |
+| Provider `default_headers` | No (provider config) | No | Re-evaluated every run |
+
+## Limitations
+
+- Resource-only; use `default_headers` or sensitive attributes on data sources, actions, and ephemeral resources
+- Private state snapshot is not zero-persistence storage
+- Digest credentials remain stateful today; write-only digest auth is future work

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -50,4 +50,12 @@ See the [HTTP Digest Authentication guide](guides/digest_auth) for configuration
 
 {{ tffile "examples/provider/digest_auth_example.tf" }}
 
+## Write-Only Headers and Request Bodies
+
+TerraCurl supports write-only `headers_wo` and `request_body_wo` attributes on `terracurl_request` resources (Terraform 1.11+). Values are sent on HTTP calls but are not stored in Terraform state.
+
+See the [Write-Only Headers and Request Bodies guide](guides/write_only) for version attributes, read/destroy private-state behavior, and comparison with `default_headers`.
+
+{{ tffile "examples/provider/write_only_example.tf" }}
+
 ## Limitations


### PR DESCRIPTION
## Summary
- Add write-only `headers_wo` and `request_body_wo` (plus read/destroy variants) on `terracurl_request` with `_wo_version` companions
- Snapshot read/destroy write-only values in provider private state during Create/Update for use in Read/Delete
- Merge write-only headers after provider `default_headers`; redact write-only bodies in debug logs

## Test plan
- [x] `go test ./internal/provider/... -run WriteOnly`
- [x] `go test ./...`
- [x] `go generate ./...`


Made with [Cursor](https://cursor.com)