### PR TITLE
Add delete-time destroy response templating (Closes #125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.9.0
+
+ENHANCEMENTS:
+
+- Add delete-time `{response.<path>}` templating in `terracurl_request` destroy URL, body, headers, and query parameters, resolved from the stored create response. Includes create-time validation and supports nested JSON paths. Closes #125.
+
 ## 2.8.0
 
 ENHANCEMENTS:

--- a/docs/guides/destroy_templating.md
+++ b/docs/guides/destroy_templating.md
@@ -1,0 +1,140 @@
+---
+page_title: "Destroy Response Templating"
+subcategory: "Guides"
+description: |-
+  Use {response.path} placeholders in destroy configuration to inject values from the stored create response at delete time.
+---
+
+# Destroy Response Templating
+
+Many REST APIs return a server-generated identifier when a resource is created. The delete API often requires that same identifier in the URL, request body, or query parameters. Terraform cannot reference a resource's own computed `response` attribute inside the same resource block, and TerraCurl reads destroy configuration from **stored state** at delete time rather than re-evaluating HCL expressions.
+
+TerraCurl resolves **`{response.<path>}`** placeholders in destroy fields from the stored create response JSON when the resource is destroyed.
+
+## When to use destroy templating
+
+Use placeholders when:
+
+- Create returns an ID (or other value) needed for delete
+- The value lives in the create response JSON at a known path
+- You manage create and destroy in a single `terracurl_request` resource
+
+## Placeholder syntax
+
+| Pattern | Meaning |
+|---------|---------|
+| `{response.id}` | Top-level `id` field in create response |
+| `{response.data.uuid}` | Nested field using dot-separated path |
+| `{response.items.0.id}` | Array element at index `0` |
+
+`{response...}` refers to the **stored create response JSON**, not the Terraform resource `id` (which is always `name`).
+
+Placeholders work in:
+
+- `destroy_url`
+- `destroy_request_body` and `destroy_request_body_wo`
+- `destroy_request_parameters` (map values)
+- `destroy_headers` and `destroy_headers_wo` (map values)
+
+If a string contains no `{response.` substring, it is passed through unchanged.
+
+## Example: delete by URL path
+
+```terraform
+resource "terracurl_request" "object" {
+  name           = "my-object"
+  url            = "https://api.example.com/objects"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/objects/{response.id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200, 204]
+}
+```
+
+Create response `{"id":"abc-123"}` → destroy calls `DELETE .../objects/abc-123`.
+
+## Example: nested response field
+
+```terraform
+resource "terracurl_request" "object" {
+  name           = "my-object"
+  url            = "https://api.example.com/objects"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/objects/{response.result.object_id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200]
+}
+```
+
+Create response:
+
+```json
+{
+  "status": "created",
+  "result": {
+    "object_id": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+## Example: delete by request body
+
+```terraform
+resource "terracurl_request" "user" {
+  name           = "user"
+  url            = "https://api.example.com/users"
+  method         = "POST"
+  request_body   = jsonencode({ name = "john" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/deactivate"
+  destroy_method         = "POST"
+  destroy_request_body   = jsonencode({ user_id = "{response.data.user.uuid}" })
+  destroy_response_codes = [200]
+}
+```
+
+## Create-time validation
+
+After a successful create, TerraCurl validates that all `{response...}` placeholders in destroy configuration resolve against the create response. Mis-typed paths (for example `{response.uuid}` when the API returns `{response.id}`) fail at apply time instead of during a later destroy.
+
+Validation is skipped when `skip_destroy = true`.
+
+## Sensitive responses
+
+When `response_sensitive = true`, placeholders resolve from `sensitive_response` in state. Template strings in destroy configuration remain in state as written; only the resolved values are sent on the wire at destroy time.
+
+## Escaping literal braces
+
+To include a literal `{response.id}` in a value without substitution, wrap the placeholder in double braces:
+
+```text
+{{response.id}}
+```
+
+This renders as `{response.id}` in the outbound request.
+
+## Limitations
+
+- Placeholders require a valid JSON create response stored in state
+- Imported resources without a stored response cannot use destroy templating
+- Paths must reference fields that remain after `ignore_response_fields` sanitization
+- Only scalar values (string, number, boolean) can be substituted; objects and arrays as whole values are not supported
+- Read-time templating for `read_url` / `read_request_body` is not supported in this release
+
+## Related guides
+
+- [Default Headers for Auth Tokens](default_headers) — refresh auth headers on every Terraform run, including destroy
+- [Write-Only Headers and Request Bodies](write_only) — secrets in destroy bodies without persisting them in state

--- a/docs/index.md
+++ b/docs/index.md
@@ -204,4 +204,55 @@ resource "terracurl_request" "example" {
 }
 ```
 
+## Destroy Response Templating
+
+TerraCurl resolves `{response.<path>}` placeholders in destroy URL, body, headers, and query parameters from the stored create response at delete time. This supports APIs that return a server-generated ID needed for delete without Terraform self-references.
+
+See the [Destroy Response Templating guide](guides/destroy_templating) for syntax, nested paths, body-based delete, and create-time validation.
+
+```terraform
+resource "terracurl_request" "object" {
+  name           = "example-object"
+  url            = "https://api.example.com/objects"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/objects/{response.id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200, 204]
+}
+
+resource "terracurl_request" "nested_object" {
+  name           = "nested-object"
+  url            = "https://api.example.com/objects"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/objects/{response.data.object_id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200]
+}
+
+resource "terracurl_request" "body_destroy" {
+  name           = "body-destroy"
+  url            = "https://api.example.com/users"
+  method         = "POST"
+  request_body   = jsonencode({ name = "john" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/deactivate"
+  destroy_method         = "POST"
+  destroy_request_body   = jsonencode({ user_id = "{response.data.user.uuid}" })
+  destroy_response_codes = [200]
+}
+```
+
 ## Limitations

--- a/docs/resources/request.md
+++ b/docs/resources/request.md
@@ -34,21 +34,21 @@ When `skip_read` is `false` and `read_url`, `read_method`, and `read_response_co
 - `destroy_ca_cert_file` (String) Path to a file on local disk that will be used to validate the certificate presented by the server for the destroy call
 - `destroy_cert_file` (String) Path to a file on local disk that contains the PEM-encoded certificate to present to the server for the destroy call
 - `destroy_digest_auth` (Attributes, Sensitive) HTTP Digest authentication credentials for the destroy request. Overrides provider `default_digest_auth` when configured. (see [below for nested schema](#nestedatt--destroy_digest_auth))
-- `destroy_headers` (Map of String) Map of headers to attach to the destroy API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
+- `destroy_headers` (Map of String) Map of headers to attach to the destroy API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname. Values support `{response.<path>}` placeholders resolved from the stored create response at destroy time.
 - `destroy_headers_wo` (Map of String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only headers for the destroy call. Snapshotted in provider private state for use during destroy.
 - `destroy_headers_wo_version` (Number) Increment to trigger refreshing snapshotted `destroy_headers_wo` values.
 - `destroy_key_file` (String) Path to a file on local disk that contains the PEM-encoded private key for which the authentication certificate was issued for the destroy call
 - `destroy_max_retry` (Number) Maximum number of tries until it is marked as failed for the destroy call
 - `destroy_method` (String) Destroy HTTP method to use in the API call
-- `destroy_request_body` (String) A request body to attach to the destroy API call
+- `destroy_request_body` (String) A request body to attach to the destroy API call. Supports `{response.<path>}` placeholders resolved from the stored create response at destroy time.
 - `destroy_request_body_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only request body for the destroy call. Not stored in Terraform state.
 - `destroy_request_body_wo_version` (Number) Increment to trigger applying an updated `destroy_request_body_wo` value.
-- `destroy_request_parameters` (Map of String) Map of parameters to attach to the destroy API call
+- `destroy_request_parameters` (Map of String) Map of parameters to attach to the destroy API call. Values support `{response.<path>}` placeholders resolved from the stored create response at destroy time.
 - `destroy_response_codes` (List of String) A list of expected response codes for the destroy call
 - `destroy_retry_interval` (Number) Interval between each attempt for the destroy call
 - `destroy_skip_tls_verify` (Boolean) Set this to true to disable verification of the server's TLS certificate for the destroy call
 - `destroy_timeout` (Number) Time in seconds before each request times out for the destroy call. Defaults to 10
-- `destroy_url` (String) Destroy API endpoint to call
+- `destroy_url` (String) Destroy API endpoint to call. Supports `{response.<path>}` placeholders resolved from the stored create response at destroy time. See the [Destroy Response Templating guide](../guides/destroy_templating).
 - `digest_auth` (Attributes, Sensitive) HTTP Digest authentication credentials for the create request. Overrides provider `default_digest_auth` when configured. (see [below for nested schema](#nestedatt--digest_auth))
 - `headers` (Map of String) Map of headers to attach to the API call. Host (case-insensitive) overrides the HTTP Host header sent on the wire, independent of the URL hostname.
 - `headers_wo` (Map of String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only headers for the create call. Not stored in Terraform state. Requires Terraform 1.11 or later.

--- a/examples/resources/destroy_templating_example/resource.tf
+++ b/examples/resources/destroy_templating_example/resource.tf
@@ -1,0 +1,42 @@
+resource "terracurl_request" "object" {
+  name           = "example-object"
+  url            = "https://api.example.com/objects"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/objects/{response.id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200, 204]
+}
+
+resource "terracurl_request" "nested_object" {
+  name           = "nested-object"
+  url            = "https://api.example.com/objects"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/objects/{response.data.object_id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200]
+}
+
+resource "terracurl_request" "body_destroy" {
+  name           = "body-destroy"
+  url            = "https://api.example.com/users"
+  method         = "POST"
+  request_body   = jsonencode({ name = "john" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/deactivate"
+  destroy_method         = "POST"
+  destroy_request_body   = jsonencode({ user_id = "{response.data.user.uuid}" })
+  destroy_response_codes = [200]
+}

--- a/internal/provider/curl_resource.go
+++ b/internal/provider/curl_resource.go
@@ -276,7 +276,7 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 
 			"destroy_url": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Destroy API endpoint to call",
+				MarkdownDescription: "Destroy API endpoint to call. Supports `{response.<path>}` placeholders resolved from the stored create response at destroy time. See the [Destroy Response Templating guide](../guides/destroy_templating).",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -290,7 +290,7 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			},
 			"destroy_request_body": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "A request body to attach to the destroy API call",
+				MarkdownDescription: "A request body to attach to the destroy API call. Supports `{response.<path>}` placeholders resolved from the stored create response at destroy time.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -303,7 +303,7 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"destroy_headers": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of headers to attach to the destroy API call." + hostHeaderMarkdownSuffix,
+				MarkdownDescription: "Map of headers to attach to the destroy API call." + hostHeaderMarkdownSuffix + " Values support `{response.<path>}` placeholders resolved from the stored create response at destroy time.",
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.RequiresReplace(),
 				},
@@ -317,7 +317,7 @@ func (r *CurlResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"destroy_request_parameters": schema.MapAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
-				MarkdownDescription: "Map of parameters to attach to the destroy API call",
+				MarkdownDescription: "Map of parameters to attach to the destroy API call. Values support `{response.<path>}` placeholders resolved from the stored create response at destroy time.",
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.RequiresReplace(),
 				},
@@ -662,6 +662,14 @@ func (r *CurlResource) Create(ctx context.Context, req resource.CreateRequest, r
 	data.RequestUrlString = types.StringValue(request.URL.String())
 	setResourceResponseValues(&data, sanitizedResponse)
 	data.StatusCode = types.StringValue(strconv.Itoa(statusCode))
+
+	if !data.SkipDestroy.ValueBool() {
+		resp.Diagnostics.Append(validateDestroyTemplates(data)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	resp.Diagnostics.Append(snapshotWriteOnlyToPrivate(ctx, configModel, resp.Private)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -958,26 +966,31 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	// Build Destroy Request
-	var reqBody io.Reader
-	destroyBody, usedWriteOnlyBody := resolveRequestBody(data.DestroyRequestBody, data.DestroyRequestBodyWo)
-	if len(destroyBody) > 0 {
-		reqBody = bytes.NewBuffer(destroyBody)
+	resolved, templateDiags := resolveDestroyTemplates(&data)
+	resp.Diagnostics.Append(templateDiags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	request, err := http.NewRequest(data.DestroyMethod.ValueString(), data.DestroyUrl.ValueString(), reqBody)
+	// Build Destroy Request
+	var reqBody io.Reader
+	if len(resolved.Body) > 0 {
+		reqBody = bytes.NewBuffer(resolved.Body)
+	}
+
+	request, err := http.NewRequest(data.DestroyMethod.ValueString(), resolved.URL, reqBody)
 	if err != nil {
 		resp.Diagnostics.AddError("Destroy Error", fmt.Sprintf("Failed to create request: %s", err))
 		return
 	}
 
 	// Add Headers
-	applyRequestHeadersWithWriteOnly(request, data.DestroyHeaders, data.DestroyHeadersWo, r.providerMeta())
+	applyRequestHeadersWithWriteOnly(request, resolved.DestroyHeaders, resolved.DestroyHeadersWo, r.providerMeta())
 
 	// Add Query Parameters
-	if !data.DestroyRequestParameters.IsNull() && !data.DestroyRequestParameters.IsUnknown() {
+	if !resolved.DestroyParams.IsNull() && !resolved.DestroyParams.IsUnknown() {
 		params := request.URL.Query()
-		for k, v := range data.DestroyRequestParameters.Elements() {
+		for k, v := range resolved.DestroyParams.Elements() {
 			if strVal, ok := v.(types.String); ok {
 				params.Add(k, strVal.ValueString())
 			}
@@ -990,7 +1003,7 @@ func (r *CurlResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	retryInterval := time.Duration(data.DestroyRetryInterval.ValueInt64()) * time.Second
 	maxRetry := int(data.DestroyMaxRetry.ValueInt64())
 
-	tflog.Debug(ctx, fmt.Sprintf("Resource destroy API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.DestroyRequestBody, usedWriteOnlyBody)))
+	tflog.Debug(ctx, fmt.Sprintf("Resource destroy API Call: \nURL: %s\nHeaders: %s\nMethod: %s\nRequest Body: %s\n", request.URL.String(), request.Header, request.Method, requestBodyForLog(data.DestroyRequestBody, resolved.BodyUsedWriteOnly)))
 
 	var bodyBytes []byte
 	var statusCode int

--- a/internal/provider/curl_resource_test.go
+++ b/internal/provider/curl_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jarcoal/httpmock"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -191,6 +192,166 @@ EOF
 
 
 }`, name, requestBody, requestBody)
+}
+
+func TestAccresourceCurlDestroyTemplatingFlatID(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/create",
+		httpmock.NewStringResponder(201, `{"id":"uuid-123"}`),
+	)
+	httpmock.RegisterResponder(
+		"DELETE",
+		"https://example.com/objects/uuid-123",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testMockEndpointCount("DELETE https://example.com/objects/uuid-123", 1),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceCurlDestroyTemplatingFlatID(rName),
+			},
+		},
+	})
+}
+
+func testAccresourceCurlDestroyTemplatingFlatID(name string) string {
+	return fmt.Sprintf(`
+resource "terracurl_request" "templated_destroy" {
+  name           = "%s"
+  url            = "https://example.com/create"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://example.com/objects/{response.id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200]
+}
+`, name)
+}
+
+func TestAccresourceCurlDestroyTemplatingNestedID(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/create",
+		httpmock.NewStringResponder(201, `{"data":{"object_id":"nested-456"}}`),
+	)
+	httpmock.RegisterResponder(
+		"DELETE",
+		"https://example.com/objects/nested-456",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testMockEndpointCount("DELETE https://example.com/objects/nested-456", 1),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceCurlDestroyTemplatingNestedID(rName),
+			},
+		},
+	})
+}
+
+func testAccresourceCurlDestroyTemplatingNestedID(name string) string {
+	return fmt.Sprintf(`
+resource "terracurl_request" "templated_destroy" {
+  name           = "%s"
+  url            = "https://example.com/create"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://example.com/objects/{response.data.object_id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200]
+}
+`, name)
+}
+
+func TestAccresourceCurlDestroyTemplatingBody(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/create",
+		httpmock.NewStringResponder(201, `{"id":"uuid-123"}`),
+	)
+
+	var capturedDestroyBody string
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/deactivate",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			capturedDestroyBody = string(body)
+			return httpmock.NewStringResponse(200, `{}`), nil
+		},
+	)
+
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			expected := `{"id":"uuid-123"}`
+			if capturedDestroyBody != expected {
+				return fmt.Errorf("destroy body %q, expected %q", capturedDestroyBody, expected)
+			}
+			return testMockEndpointCount("POST https://example.com/deactivate", 1)(s)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceCurlDestroyTemplatingBody(rName),
+			},
+		},
+	})
+}
+
+func testAccresourceCurlDestroyTemplatingBody(name string) string {
+	return fmt.Sprintf(`
+resource "terracurl_request" "templated_destroy" {
+  name           = "%s"
+  url            = "https://example.com/create"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://example.com/deactivate"
+  destroy_method         = "POST"
+  destroy_request_body   = jsonencode({ id = "{response.id}" })
+  destroy_response_codes = [200]
+}
+`, name)
 }
 
 func TestAccresourceCurlSkipDestroy(t *testing.T) {

--- a/internal/provider/destroy_template.go
+++ b/internal/provider/destroy_template.go
@@ -1,0 +1,298 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const responsePlaceholderPrefix = "{response."
+
+var responsePlaceholderPattern = regexp.MustCompile(`\{response\.([^}]+)\}`)
+
+type resolvedDestroyTemplates struct {
+	URL               string
+	Body              []byte
+	BodyUsedWriteOnly bool
+	DestroyHeaders    types.Map
+	DestroyHeadersWo  types.Map
+	DestroyParams     types.Map
+}
+
+func containsResponsePlaceholder(s string) bool {
+	return strings.Contains(s, responsePlaceholderPrefix)
+}
+
+func mapContainsResponsePlaceholder(m types.Map) bool {
+	if m.IsNull() || m.IsUnknown() {
+		return false
+	}
+	for _, v := range m.Elements() {
+		if strVal, ok := v.(types.String); ok && containsResponsePlaceholder(strVal.ValueString()) {
+			return true
+		}
+	}
+	return false
+}
+
+func destroyFieldsHavePlaceholders(data *CurlResourceModel) bool {
+	if data == nil {
+		return false
+	}
+	if hasValue(data.DestroyUrl) && containsResponsePlaceholder(data.DestroyUrl.ValueString()) {
+		return true
+	}
+	if hasValue(data.DestroyRequestBody) && containsResponsePlaceholder(data.DestroyRequestBody.ValueString()) {
+		return true
+	}
+	if hasValue(data.DestroyRequestBodyWo) && containsResponsePlaceholder(data.DestroyRequestBodyWo.ValueString()) {
+		return true
+	}
+	return mapContainsResponsePlaceholder(data.DestroyHeaders) ||
+		mapContainsResponsePlaceholder(data.DestroyHeadersWo) ||
+		mapContainsResponsePlaceholder(data.DestroyRequestParameters)
+}
+
+func extractJSONPath(jsonStr, path string) (string, error) {
+	if jsonStr == "" {
+		return "", fmt.Errorf("response is empty")
+	}
+
+	var root interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &root); err != nil {
+		return "", fmt.Errorf("response is not valid JSON: %w", err)
+	}
+
+	current := root
+	for _, seg := range strings.Split(path, ".") {
+		if current == nil {
+			return "", fmt.Errorf("path %q not found in response", path)
+		}
+
+		switch v := current.(type) {
+		case map[string]interface{}:
+			val, ok := v[seg]
+			if !ok {
+				return "", fmt.Errorf("path %q not found in response", path)
+			}
+			current = val
+		case []interface{}:
+			idx, err := strconv.Atoi(seg)
+			if err != nil {
+				return "", fmt.Errorf("path %q: expected array index, got %q", path, seg)
+			}
+			if idx < 0 || idx >= len(v) {
+				return "", fmt.Errorf("path %q not found in response", path)
+			}
+			current = v[idx]
+		default:
+			return "", fmt.Errorf("path %q not found in response", path)
+		}
+	}
+
+	return stringifyJSONValue(current)
+}
+
+func stringifyJSONValue(v interface{}) (string, error) {
+	if v == nil {
+		return "", fmt.Errorf("value at path is null")
+	}
+
+	switch val := v.(type) {
+	case string:
+		return val, nil
+	case float64:
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10), nil
+		}
+		return strconv.FormatFloat(val, 'f', -1, 64), nil
+	case bool:
+		return strconv.FormatBool(val), nil
+	default:
+		return "", fmt.Errorf("value at path is not a scalar (got %T)", v)
+	}
+}
+
+func unescapeDoubleBraces(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if i+1 < len(s) && s[i] == '{' && s[i+1] == '{' {
+			b.WriteByte('{')
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+var escapedResponsePlaceholderPattern = regexp.MustCompile(`\{\{response\.([^}]+)\}\}`)
+
+func substituteResponsePlaceholders(template, responseJSON string) (string, error) {
+	if !containsResponsePlaceholder(template) {
+		return template, nil
+	}
+
+	type escapedToken struct {
+		literal string
+	}
+	var tokens []escapedToken
+
+	protected := escapedResponsePlaceholderPattern.ReplaceAllStringFunc(template, func(match string) string {
+		submatches := escapedResponsePlaceholderPattern.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+		idx := len(tokens)
+		tokens = append(tokens, escapedToken{literal: "{response." + submatches[1] + "}"})
+		return fmt.Sprintf("\x00ESC%d\x00", idx)
+	})
+
+	unescaped := unescapeDoubleBraces(protected)
+
+	var substErr error
+	result := responsePlaceholderPattern.ReplaceAllStringFunc(unescaped, func(match string) string {
+		if substErr != nil {
+			return match
+		}
+		submatches := responsePlaceholderPattern.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+		value, err := extractJSONPath(responseJSON, submatches[1])
+		if err != nil {
+			substErr = fmt.Errorf("placeholder %s: %w", match, err)
+			return match
+		}
+		return value
+	})
+	if substErr != nil {
+		return "", substErr
+	}
+
+	for i, token := range tokens {
+		result = strings.ReplaceAll(result, fmt.Sprintf("\x00ESC%d\x00", i), token.literal)
+	}
+
+	return result, nil
+}
+
+func substituteFieldPlaceholders(value, responseJSON, fieldName string) (string, error) {
+	if !containsResponsePlaceholder(value) {
+		return value, nil
+	}
+	result, err := substituteResponsePlaceholders(value, responseJSON)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", fieldName, err)
+	}
+	return result, nil
+}
+
+func substituteMapPlaceholders(m types.Map, responseJSON, fieldName string) (types.Map, error) {
+	if m.IsNull() || m.IsUnknown() {
+		return m, nil
+	}
+
+	result := make(map[string]types.String, len(m.Elements()))
+	for k, v := range m.Elements() {
+		strVal, ok := v.(types.String)
+		if !ok {
+			continue
+		}
+		substituted, err := substituteFieldPlaceholders(strVal.ValueString(), responseJSON, fieldName)
+		if err != nil {
+			return types.MapNull(types.StringType), err
+		}
+		result[k] = types.StringValue(substituted)
+	}
+
+	tfMap, diags := types.MapValueFrom(context.Background(), types.StringType, result)
+	if diags.HasError() {
+		return types.MapNull(types.StringType), fmt.Errorf("%s: failed to build map value", fieldName)
+	}
+	return tfMap, nil
+}
+
+func resolveDestroyTemplates(data *CurlResourceModel) (resolvedDestroyTemplates, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var resolved resolvedDestroyTemplates
+
+	if data == nil {
+		return resolved, diags
+	}
+
+	destroyBody, usedWriteOnlyBody := resolveRequestBody(data.DestroyRequestBody, data.DestroyRequestBodyWo)
+	resolved.URL = data.DestroyUrl.ValueString()
+	resolved.Body = destroyBody
+	resolved.BodyUsedWriteOnly = usedWriteOnlyBody
+	resolved.DestroyHeaders = data.DestroyHeaders
+	resolved.DestroyHeadersWo = data.DestroyHeadersWo
+	resolved.DestroyParams = data.DestroyRequestParameters
+
+	if !destroyFieldsHavePlaceholders(data) {
+		return resolved, diags
+	}
+
+	responseJSON := priorResponseValue(data.ResponseSensitive, data.Response, data.SensitiveResponse)
+	if responseJSON == "" {
+		diags.AddError(
+			"Destroy Template Error",
+			"Destroy configuration contains {response...} placeholders but the stored create response is empty.",
+		)
+		return resolved, diags
+	}
+
+	url, err := substituteFieldPlaceholders(data.DestroyUrl.ValueString(), responseJSON, "destroy_url")
+	if err != nil {
+		diags.AddError("Destroy Template Error", err.Error())
+		return resolved, diags
+	}
+	resolved.URL = url
+
+	if len(destroyBody) > 0 {
+		bodyStr, err := substituteFieldPlaceholders(string(destroyBody), responseJSON, "destroy_request_body")
+		if err != nil {
+			diags.AddError("Destroy Template Error", err.Error())
+			return resolved, diags
+		}
+		resolved.Body = []byte(bodyStr)
+	}
+
+	headers, err := substituteMapPlaceholders(data.DestroyHeaders, responseJSON, "destroy_headers")
+	if err != nil {
+		diags.AddError("Destroy Template Error", err.Error())
+		return resolved, diags
+	}
+	resolved.DestroyHeaders = headers
+
+	headersWo, err := substituteMapPlaceholders(data.DestroyHeadersWo, responseJSON, "destroy_headers_wo")
+	if err != nil {
+		diags.AddError("Destroy Template Error", err.Error())
+		return resolved, diags
+	}
+	resolved.DestroyHeadersWo = headersWo
+
+	params, err := substituteMapPlaceholders(data.DestroyRequestParameters, responseJSON, "destroy_request_parameters")
+	if err != nil {
+		diags.AddError("Destroy Template Error", err.Error())
+		return resolved, diags
+	}
+	resolved.DestroyParams = params
+
+	return resolved, diags
+}
+
+func validateDestroyTemplates(data CurlResourceModel) diag.Diagnostics {
+	if data.SkipDestroy.ValueBool() {
+		return nil
+	}
+	_, diags := resolveDestroyTemplates(&data)
+	return diags
+}

--- a/internal/provider/destroy_template_test.go
+++ b/internal/provider/destroy_template_test.go
@@ -1,0 +1,182 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestContainsResponsePlaceholder(t *testing.T) {
+	if containsResponsePlaceholder("https://example.com/{response.id}") != true {
+		t.Fatal("expected placeholder detection")
+	}
+	if containsResponsePlaceholder("https://example.com/static") != false {
+		t.Fatal("expected no placeholder")
+	}
+}
+
+func TestSubstituteResponsePlaceholders_Passthrough(t *testing.T) {
+	got, err := substituteResponsePlaceholders("https://example.com/destroy", `{"id":"abc"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/destroy" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSubstituteResponsePlaceholders_TopLevel(t *testing.T) {
+	got, err := substituteResponsePlaceholders(
+		"https://example.com/objects/{response.id}",
+		`{"id":"uuid-123"}`,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/objects/uuid-123" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSubstituteResponsePlaceholders_Nested(t *testing.T) {
+	response := `{"data":{"object_id":"nested-456"}}`
+	got, err := substituteResponsePlaceholders(
+		"https://example.com/objects/{response.data.object_id}",
+		response,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/objects/nested-456" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSubstituteResponsePlaceholders_ArrayIndex(t *testing.T) {
+	response := `{"items":[{"id":"first-id"}]}`
+	got, err := substituteResponsePlaceholders(
+		"https://example.com/{response.items.0.id}",
+		response,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/first-id" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSubstituteResponsePlaceholders_Multiple(t *testing.T) {
+	response := `{"tenant_id":"t1","user":{"id":"u1"}}`
+	got, err := substituteResponsePlaceholders(
+		"https://example.com/tenants/{response.tenant_id}/users/{response.user.id}",
+		response,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/tenants/t1/users/u1" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSubstituteResponsePlaceholders_EscapeDoubleBraces(t *testing.T) {
+	got, err := substituteResponsePlaceholders(
+		"literal {{response.id}} value",
+		`{"id":"ignored"}`,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "literal {response.id} value" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSubstituteResponsePlaceholders_MissingPath(t *testing.T) {
+	_, err := substituteResponsePlaceholders(
+		"https://example.com/{response.missing}",
+		`{"id":"abc"}`,
+	)
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+}
+
+func TestSubstituteResponsePlaceholders_NonJSONResponse(t *testing.T) {
+	_, err := substituteResponsePlaceholders(
+		"https://example.com/{response.id}",
+		"not json",
+	)
+	if err == nil {
+		t.Fatal("expected error for non-JSON response")
+	}
+}
+
+func TestExtractJSONPath_NumericAndBool(t *testing.T) {
+	response := `{"count":42,"active":true}`
+
+	count, err := extractJSONPath(response, "count")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != "42" {
+		t.Fatalf("count got %q", count)
+	}
+
+	active, err := extractJSONPath(response, "active")
+	if err != nil {
+		t.Fatalf("active: %v", err)
+	}
+	if active != "true" {
+		t.Fatalf("active got %q", active)
+	}
+}
+
+func TestResolveDestroyTemplates_NoPlaceholders(t *testing.T) {
+	data := &CurlResourceModel{
+		DestroyUrl: types.StringValue("https://example.com/destroy"),
+		DestroyRequestBody: types.StringValue(`{"static":true}`),
+	}
+
+	resolved, diags := resolveDestroyTemplates(data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if resolved.URL != "https://example.com/destroy" {
+		t.Fatalf("url got %q", resolved.URL)
+	}
+	if string(resolved.Body) != `{"static":true}` {
+		t.Fatalf("body got %q", string(resolved.Body))
+	}
+}
+
+func TestResolveDestroyTemplates_WithNestedPlaceholder(t *testing.T) {
+	data := &CurlResourceModel{
+		Response:     types.StringValue(`{"data":{"object_id":"nested-456"}}`),
+		DestroyUrl:   types.StringValue("https://example.com/objects/{response.data.object_id}"),
+		DestroyRequestBody: types.StringValue(`{"id":"{response.data.object_id}"}`),
+	}
+
+	resolved, diags := resolveDestroyTemplates(data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if resolved.URL != "https://example.com/objects/nested-456" {
+		t.Fatalf("url got %q", resolved.URL)
+	}
+	if string(resolved.Body) != `{"id":"nested-456"}` {
+		t.Fatalf("body got %q", string(resolved.Body))
+	}
+}
+
+func TestValidateDestroyTemplates_SkipDestroy(t *testing.T) {
+	data := CurlResourceModel{
+		SkipDestroy: types.BoolValue(true),
+		DestroyUrl:  types.StringValue("https://example.com/{response.id}"),
+	}
+	diags := validateDestroyTemplates(data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+}

--- a/internal/provider/destroy_template_test.go
+++ b/internal/provider/destroy_template_test.go
@@ -135,7 +135,7 @@ func TestExtractJSONPath_NumericAndBool(t *testing.T) {
 
 func TestResolveDestroyTemplates_NoPlaceholders(t *testing.T) {
 	data := &CurlResourceModel{
-		DestroyUrl: types.StringValue("https://example.com/destroy"),
+		DestroyUrl:         types.StringValue("https://example.com/destroy"),
 		DestroyRequestBody: types.StringValue(`{"static":true}`),
 	}
 
@@ -153,8 +153,8 @@ func TestResolveDestroyTemplates_NoPlaceholders(t *testing.T) {
 
 func TestResolveDestroyTemplates_WithNestedPlaceholder(t *testing.T) {
 	data := &CurlResourceModel{
-		Response:     types.StringValue(`{"data":{"object_id":"nested-456"}}`),
-		DestroyUrl:   types.StringValue("https://example.com/objects/{response.data.object_id}"),
+		Response:           types.StringValue(`{"data":{"object_id":"nested-456"}}`),
+		DestroyUrl:         types.StringValue("https://example.com/objects/{response.data.object_id}"),
 		DestroyRequestBody: types.StringValue(`{"id":"{response.data.object_id}"}`),
 	}
 

--- a/templates/guides/destroy_templating.md.tmpl
+++ b/templates/guides/destroy_templating.md.tmpl
@@ -1,0 +1,140 @@
+---
+page_title: "Destroy Response Templating"
+subcategory: "Guides"
+description: |-
+  Use {response.path} placeholders in destroy configuration to inject values from the stored create response at delete time.
+---
+
+# Destroy Response Templating
+
+Many REST APIs return a server-generated identifier when a resource is created. The delete API often requires that same identifier in the URL, request body, or query parameters. Terraform cannot reference a resource's own computed `response` attribute inside the same resource block, and TerraCurl reads destroy configuration from **stored state** at delete time rather than re-evaluating HCL expressions.
+
+TerraCurl resolves **`{response.<path>}`** placeholders in destroy fields from the stored create response JSON when the resource is destroyed.
+
+## When to use destroy templating
+
+Use placeholders when:
+
+- Create returns an ID (or other value) needed for delete
+- The value lives in the create response JSON at a known path
+- You manage create and destroy in a single `terracurl_request` resource
+
+## Placeholder syntax
+
+| Pattern | Meaning |
+|---------|---------|
+| `{response.id}` | Top-level `id` field in create response |
+| `{response.data.uuid}` | Nested field using dot-separated path |
+| `{response.items.0.id}` | Array element at index `0` |
+
+`{response...}` refers to the **stored create response JSON**, not the Terraform resource `id` (which is always `name`).
+
+Placeholders work in:
+
+- `destroy_url`
+- `destroy_request_body` and `destroy_request_body_wo`
+- `destroy_request_parameters` (map values)
+- `destroy_headers` and `destroy_headers_wo` (map values)
+
+If a string contains no `{response.` substring, it is passed through unchanged.
+
+## Example: delete by URL path
+
+```terraform
+resource "terracurl_request" "object" {
+  name           = "my-object"
+  url            = "https://api.example.com/objects"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/objects/{response.id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200, 204]
+}
+```
+
+Create response `{"id":"abc-123"}` → destroy calls `DELETE .../objects/abc-123`.
+
+## Example: nested response field
+
+```terraform
+resource "terracurl_request" "object" {
+  name           = "my-object"
+  url            = "https://api.example.com/objects"
+  method         = "POST"
+  request_body   = jsonencode({ name = "example" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/objects/{response.result.object_id}"
+  destroy_method         = "DELETE"
+  destroy_response_codes = [200]
+}
+```
+
+Create response:
+
+```json
+{
+  "status": "created",
+  "result": {
+    "object_id": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+## Example: delete by request body
+
+```terraform
+resource "terracurl_request" "user" {
+  name           = "user"
+  url            = "https://api.example.com/users"
+  method         = "POST"
+  request_body   = jsonencode({ name = "john" })
+  response_codes = [201]
+  skip_read      = true
+  skip_destroy   = false
+
+  destroy_url            = "https://api.example.com/deactivate"
+  destroy_method         = "POST"
+  destroy_request_body   = jsonencode({ user_id = "{response.data.user.uuid}" })
+  destroy_response_codes = [200]
+}
+```
+
+## Create-time validation
+
+After a successful create, TerraCurl validates that all `{response...}` placeholders in destroy configuration resolve against the create response. Mis-typed paths (for example `{response.uuid}` when the API returns `{response.id}`) fail at apply time instead of during a later destroy.
+
+Validation is skipped when `skip_destroy = true`.
+
+## Sensitive responses
+
+When `response_sensitive = true`, placeholders resolve from `sensitive_response` in state. Template strings in destroy configuration remain in state as written; only the resolved values are sent on the wire at destroy time.
+
+## Escaping literal braces
+
+To include a literal `{response.id}` in a value without substitution, wrap the placeholder in double braces:
+
+```text
+{{ "{{response.id}}" }}
+```
+
+This renders as `{response.id}` in the outbound request.
+
+## Limitations
+
+- Placeholders require a valid JSON create response stored in state
+- Imported resources without a stored response cannot use destroy templating
+- Paths must reference fields that remain after `ignore_response_fields` sanitization
+- Only scalar values (string, number, boolean) can be substituted; objects and arrays as whole values are not supported
+- Read-time templating for `read_url` / `read_request_body` is not supported in this release
+
+## Related guides
+
+- [Default Headers for Auth Tokens](default_headers) — refresh auth headers on every Terraform run, including destroy
+- [Write-Only Headers and Request Bodies](write_only) — secrets in destroy bodies without persisting them in state

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -58,4 +58,12 @@ See the [Write-Only Headers and Request Bodies guide](guides/write_only) for ver
 
 {{ tffile "examples/provider/write_only_example.tf" }}
 
+## Destroy Response Templating
+
+TerraCurl resolves `{response.<path>}` placeholders in destroy URL, body, headers, and query parameters from the stored create response at delete time. This supports APIs that return a server-generated ID needed for delete without Terraform self-references.
+
+See the [Destroy Response Templating guide](guides/destroy_templating) for syntax, nested paths, body-based delete, and create-time validation.
+
+{{ tffile "examples/resources/destroy_templating_example/resource.tf" }}
+
 ## Limitations


### PR DESCRIPTION
## Summary
- Add opt-in `{response.<path>}` placeholder substitution in `terracurl_request` destroy URL, body, headers, and query parameters at delete time
- Resolve values from the stored create response JSON (including nested paths and array indexes), with create-time validation after successful create
- Existing destroy configs without placeholders are unchanged; includes guide, examples, tests, and CHANGELOG 2.9.0 entry

## Test plan
- [x] Unit tests for path extraction, substitution, escaping, and error cases
- [x] Acceptance tests for flat ID, nested ID, and body-based destroy templating
- [x] Full `go test ./...` passes
- [x] CI green on this PR

Closes #125

Made with [Cursor](https://cursor.com)