### PR TITLE
Add base64 response attributes to data source (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.11.0
+
+ENHANCEMENTS:
+
+- Add `response_base64` and `sensitive_response_base64` computed attributes to the `terracurl_request` data source for lossless binary response download via RFC 4648 base64 encoding. Closes #62.
+
 ## 2.10.0
 
 ENHANCEMENTS:

--- a/docs/data-sources/request.md
+++ b/docs/data-sources/request.md
@@ -44,8 +44,10 @@ TerraCurl request data source
 
 - `id` (String) Example identifier
 - `request_url_string` (String) Request URL includes parameters if request specified
-- `response` (String) JSON response received from request. Empty when `response_sensitive` is `true`; use `sensitive_response` instead.
-- `sensitive_response` (String, Sensitive) JSON response received from request, marked as sensitive so it is not displayed in plan output. Populated only when `response_sensitive` is `true`.
+- `response` (String) JSON response received from request. Empty when `response_sensitive` is `true`; use `sensitive_response` instead. For binary responses, use `response_base64` instead.
+- `response_base64` (String) Response body encoded as base64 (standard) as defined in RFC 4648. Use this for binary content. Empty when `response_sensitive` is `true`; use `sensitive_response_base64` instead.
+- `sensitive_response` (String, Sensitive) JSON response received from request, marked as sensitive so it is not displayed in plan output. Populated only when `response_sensitive` is `true`. For binary responses, use `sensitive_response_base64` instead.
+- `sensitive_response_base64` (String, Sensitive) Response body encoded as base64 (standard) as defined in RFC 4648, marked as sensitive. Populated only when `response_sensitive` is `true`.
 - `status_code` (String) Response status code received from request
 
 <a id="nestedatt--digest_auth"></a>

--- a/docs/guides/file_and_multipart_bodies.md
+++ b/docs/guides/file_and_multipart_bodies.md
@@ -170,6 +170,12 @@ Write-only string bodies (`*_request_body_wo`) remain available for inline secre
 
 See the [Destroy Response Templating guide](destroy_templating) for placeholder syntax.
 
+## Binary response bodies (data source)
+
+To download binary files without UTF-8 corruption, use the data source computed attributes `response_base64` and `sensitive_response_base64`. These encode the raw response bytes with RFC 4648 standard base64. Decode in Terraform with `base64decode()` (for example when writing to disk with `local_file`).
+
+See [`examples/data-sources/binary_response_example`](../../examples/data-sources/binary_response_example/data-source.tf).
+
 ## Limitations
 
 - File contents are loaded fully into memory at request time (same as embedding bytes in configuration).

--- a/examples/data-sources/binary_response_example/data-source.tf
+++ b/examples/data-sources/binary_response_example/data-source.tf
@@ -1,0 +1,12 @@
+data "terracurl_request" "binary_download" {
+  name           = "binary-download"
+  url            = "https://api.example.com/files/report.pdf"
+  method         = "GET"
+  response_codes = ["200"]
+}
+
+# Decode the base64 response and write to disk with the local provider.
+resource "local_file" "report" {
+  filename = "${path.module}/report.pdf"
+  content  = base64decode(data.terracurl_request.binary_download.response_base64)
+}

--- a/internal/provider/curl_data_source.go
+++ b/internal/provider/curl_data_source.go
@@ -30,30 +30,32 @@ func NewCurlDataSource() datasource.DataSource {
 }
 
 type CurlDataSourceModel struct {
-	ID                types.String          `tfsdk:"id"`
-	Name              types.String          `tfsdk:"name"`
-	Url               types.String          `tfsdk:"url"`
-	Method            types.String          `tfsdk:"method"`
-	RequestBody       types.String          `tfsdk:"request_body"`
-	RequestBodyFile   types.String          `tfsdk:"request_body_file"`
-	RequestMultipart  *MultipartConfigModel `tfsdk:"request_multipart"`
-	Headers           types.Map             `tfsdk:"headers"`
-	DigestAuth        *DigestAuthModel      `tfsdk:"digest_auth"`
-	RequestParameters types.Map             `tfsdk:"request_parameters"`
-	RequestUrlString  types.String          `tfsdk:"request_url_string"`
-	CertFile          types.String          `tfsdk:"cert_file"`
-	KeyFile           types.String          `tfsdk:"key_file"`
-	CaCertFile        types.String          `tfsdk:"ca_cert_file"`
-	CaCertDirectory   types.String          `tfsdk:"ca_cert_directory"`
-	SkipTlsVerify     types.Bool            `tfsdk:"skip_tls_verify"`
-	RetryInterval     types.Int64           `tfsdk:"retry_interval"`
-	MaxRetry          types.Int64           `tfsdk:"max_retry"`
-	Timeout           types.Int64           `tfsdk:"timeout"`
-	Response          types.String          `tfsdk:"response"`
-	SensitiveResponse types.String          `tfsdk:"sensitive_response"`
-	ResponseSensitive types.Bool            `tfsdk:"response_sensitive"`
-	ResponseCodes     types.List            `tfsdk:"response_codes"`
-	StatusCode        types.String          `tfsdk:"status_code"`
+	ID                      types.String          `tfsdk:"id"`
+	Name                    types.String          `tfsdk:"name"`
+	Url                     types.String          `tfsdk:"url"`
+	Method                  types.String          `tfsdk:"method"`
+	RequestBody             types.String          `tfsdk:"request_body"`
+	RequestBodyFile         types.String          `tfsdk:"request_body_file"`
+	RequestMultipart        *MultipartConfigModel `tfsdk:"request_multipart"`
+	Headers                 types.Map             `tfsdk:"headers"`
+	DigestAuth              *DigestAuthModel      `tfsdk:"digest_auth"`
+	RequestParameters       types.Map             `tfsdk:"request_parameters"`
+	RequestUrlString        types.String          `tfsdk:"request_url_string"`
+	CertFile                types.String          `tfsdk:"cert_file"`
+	KeyFile                 types.String          `tfsdk:"key_file"`
+	CaCertFile              types.String          `tfsdk:"ca_cert_file"`
+	CaCertDirectory         types.String          `tfsdk:"ca_cert_directory"`
+	SkipTlsVerify           types.Bool            `tfsdk:"skip_tls_verify"`
+	RetryInterval           types.Int64           `tfsdk:"retry_interval"`
+	MaxRetry                types.Int64           `tfsdk:"max_retry"`
+	Timeout                 types.Int64           `tfsdk:"timeout"`
+	Response                types.String          `tfsdk:"response"`
+	SensitiveResponse       types.String          `tfsdk:"sensitive_response"`
+	ResponseBase64          types.String          `tfsdk:"response_base64"`
+	SensitiveResponseBase64 types.String          `tfsdk:"sensitive_response_base64"`
+	ResponseSensitive       types.Bool            `tfsdk:"response_sensitive"`
+	ResponseCodes           types.List            `tfsdk:"response_codes"`
+	StatusCode              types.String          `tfsdk:"status_code"`
 }
 
 func (d *CurlDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -139,12 +141,21 @@ func (d *CurlDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			},
 			"response": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "JSON response received from request. Empty when `response_sensitive` is `true`; use `sensitive_response` instead.",
+				MarkdownDescription: "JSON response received from request. Empty when `response_sensitive` is `true`; use `sensitive_response` instead. For binary responses, use `response_base64` instead.",
 			},
 			"sensitive_response": schema.StringAttribute{
 				Computed:            true,
 				Sensitive:           true,
-				MarkdownDescription: "JSON response received from request, marked as sensitive so it is not displayed in plan output. Populated only when `response_sensitive` is `true`.",
+				MarkdownDescription: "JSON response received from request, marked as sensitive so it is not displayed in plan output. Populated only when `response_sensitive` is `true`. For binary responses, use `sensitive_response_base64` instead.",
+			},
+			"response_base64": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Response body encoded as base64 (standard) as defined in RFC 4648. Use this for binary content. Empty when `response_sensitive` is `true`; use `sensitive_response_base64` instead.",
+			},
+			"sensitive_response_base64": schema.StringAttribute{
+				Computed:            true,
+				Sensitive:           true,
+				MarkdownDescription: "Response body encoded as base64 (standard) as defined in RFC 4648, marked as sensitive. Populated only when `response_sensitive` is `true`.",
 			},
 			"response_sensitive": schema.BoolAttribute{
 				Optional:            true,
@@ -302,7 +313,10 @@ func (d *CurlDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	data.RequestUrlString = types.StringValue(request.URL.String())
-	setDataSourceResponseValues(&data, bodyString)
+	if responseBodyContainsInvalidUTF8(body) {
+		tflog.Warn(ctx, "Response body is not valid UTF-8; use response_base64 for binary content")
+	}
+	setDataSourceResponseValuesFromBytes(&data, body, bodyString)
 	data.StatusCode = types.StringValue(strconv.Itoa(statusCode))
 
 	// Save data into Terraform state.

--- a/internal/provider/curl_data_source_test.go
+++ b/internal/provider/curl_data_source_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"encoding/base64"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -455,6 +456,93 @@ data "terracurl_request" "default_test" {
   url            = "https://example.com/data-default"
   method         = "GET"
   response_codes = ["200"]
+}
+`, name)
+}
+
+func TestAccDataSourceCurlResponseBase64(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	binaryBody := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02}
+	expectedBase64 := base64.StdEncoding.EncodeToString(binaryBody)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(
+		"GET",
+		"https://example.com/binary",
+		httpmock.NewBytesResponder(200, binaryBody),
+	)
+
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCurlResponseBase64(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.terracurl_request.binary_test", "response_base64", expectedBase64),
+					resource.TestCheckResourceAttr("data.terracurl_request.binary_test", "sensitive_response_base64", ""),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCurlResponseBase64(name string) string {
+	return fmt.Sprintf(`
+data "terracurl_request" "binary_test" {
+  name           = "%s"
+  url            = "https://example.com/binary"
+  method         = "GET"
+  response_codes = ["200"]
+}
+`, name)
+}
+
+func TestAccDataSourceCurlSensitiveResponseBase64(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
+	t.Setenv("USE_DEFAULT_CLIENT_FOR_TESTS", "true")
+
+	binaryBody := []byte{0x00, 0x01, 0x02, 0xff}
+	expectedBase64 := base64.StdEncoding.EncodeToString(binaryBody)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(
+		"GET",
+		"https://example.com/binary-sensitive",
+		httpmock.NewBytesResponder(200, binaryBody),
+	)
+
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCurlSensitiveResponseBase64(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.terracurl_request.binary_sensitive_test", "response_base64", ""),
+					resource.TestCheckResourceAttr("data.terracurl_request.binary_sensitive_test", "sensitive_response_base64", expectedBase64),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCurlSensitiveResponseBase64(name string) string {
+	return fmt.Sprintf(`
+data "terracurl_request" "binary_sensitive_test" {
+  name               = "%s"
+  url                = "https://example.com/binary-sensitive"
+  method             = "GET"
+  response_codes     = ["200"]
+  response_sensitive = true
 }
 `, name)
 }

--- a/internal/provider/response_base64_test.go
+++ b/internal/provider/response_base64_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestEncodeResponseBase64(t *testing.T) {
+	want := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	got := encodeResponseBase64(want)
+	if got != "iVBORw0KGgo=" {
+		t.Fatalf("got %q", got)
+	}
+
+	if encodeResponseBase64(nil) != "" {
+		t.Fatal("expected empty string for nil body")
+	}
+	if encodeResponseBase64([]byte{}) != "" {
+		t.Fatal("expected empty string for empty body")
+	}
+}
+
+func TestSetDataSourceResponseValuesFromBytes(t *testing.T) {
+	body := []byte{0x00, 0x01, 0x02}
+	encoded := base64.StdEncoding.EncodeToString(body)
+
+	t.Run("non-sensitive", func(t *testing.T) {
+		data := &CurlDataSourceModel{
+			ResponseSensitive: types.BoolValue(false),
+		}
+		setDataSourceResponseValuesFromBytes(data, body, string(body))
+
+		if data.Response.ValueString() != string(body) {
+			t.Fatalf("response got %q", data.Response.ValueString())
+		}
+		if data.ResponseBase64.ValueString() != encoded {
+			t.Fatalf("response_base64 got %q want %q", data.ResponseBase64.ValueString(), encoded)
+		}
+		if data.SensitiveResponse.ValueString() != "" || data.SensitiveResponseBase64.ValueString() != "" {
+			t.Fatal("expected sensitive response attrs to be empty")
+		}
+	})
+
+	t.Run("sensitive", func(t *testing.T) {
+		data := &CurlDataSourceModel{
+			ResponseSensitive: types.BoolValue(true),
+		}
+		setDataSourceResponseValuesFromBytes(data, body, string(body))
+
+		if data.Response.ValueString() != "" || data.ResponseBase64.ValueString() != "" {
+			t.Fatal("expected non-sensitive response attrs to be empty")
+		}
+		if data.SensitiveResponse.ValueString() != string(body) {
+			t.Fatalf("sensitive_response got %q", data.SensitiveResponse.ValueString())
+		}
+		if data.SensitiveResponseBase64.ValueString() != encoded {
+			t.Fatalf("sensitive_response_base64 got %q want %q", data.SensitiveResponseBase64.ValueString(), encoded)
+		}
+	})
+}
+
+func TestResponseBodyContainsInvalidUTF8(t *testing.T) {
+	if !responseBodyContainsInvalidUTF8([]byte{0xff, 0xfe, 0xfd}) {
+		t.Fatal("expected invalid UTF-8 detection")
+	}
+	if responseBodyContainsInvalidUTF8([]byte("hello")) {
+		t.Fatal("expected valid UTF-8")
+	}
+	if responseBodyContainsInvalidUTF8(nil) {
+		t.Fatal("expected empty body to be valid")
+	}
+}

--- a/internal/provider/utilities.go
+++ b/internal/provider/utilities.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -55,6 +57,28 @@ func setResponseValue(sensitive bool, response, sensitiveResponse *types.String,
 		*response = types.StringValue(body)
 		*sensitiveResponse = types.StringValue("")
 	}
+}
+
+func encodeResponseBase64(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(body)
+}
+
+func setResponseBase64Value(sensitive bool, response, sensitiveResponse *types.String, body []byte) {
+	encoded := encodeResponseBase64(body)
+	if sensitive {
+		*response = types.StringValue("")
+		*sensitiveResponse = types.StringValue(encoded)
+	} else {
+		*response = types.StringValue(encoded)
+		*sensitiveResponse = types.StringValue("")
+	}
+}
+
+func responseBodyContainsInvalidUTF8(body []byte) bool {
+	return len(body) > 0 && !utf8.Valid(body)
 }
 
 func responseSensitiveEnabled(value types.Bool) bool {
@@ -107,13 +131,10 @@ func setEphemeralCloseResponse(data *CurlEphemeralModel, body string) {
 	)
 }
 
-func setDataSourceResponseValues(data *CurlDataSourceModel, body string) {
-	setResponseValue(
-		responseSensitiveEnabled(data.ResponseSensitive),
-		&data.Response,
-		&data.SensitiveResponse,
-		body,
-	)
+func setDataSourceResponseValuesFromBytes(data *CurlDataSourceModel, body []byte, bodyString string) {
+	sensitive := responseSensitiveEnabled(data.ResponseSensitive)
+	setResponseValue(sensitive, &data.Response, &data.SensitiveResponse, bodyString)
+	setResponseBase64Value(sensitive, &data.ResponseBase64, &data.SensitiveResponseBase64, body)
 }
 
 func responseCodeChecker(expectedStatusCodes types.List, receivedStatusCode int) bool {

--- a/templates/guides/file_and_multipart_bodies.md.tmpl
+++ b/templates/guides/file_and_multipart_bodies.md.tmpl
@@ -170,6 +170,12 @@ Write-only string bodies (`*_request_body_wo`) remain available for inline secre
 
 See the [Destroy Response Templating guide](destroy_templating) for placeholder syntax.
 
+## Binary response bodies (data source)
+
+To download binary files without UTF-8 corruption, use the data source computed attributes `response_base64` and `sensitive_response_base64`. These encode the raw response bytes with RFC 4648 standard base64. Decode in Terraform with `base64decode()` (for example when writing to disk with `local_file`).
+
+See [`examples/data-sources/binary_response_example`](../../examples/data-sources/binary_response_example/data-source.tf).
+
 ## Limitations
 
 - File contents are loaded fully into memory at request time (same as embedding bytes in configuration).


### PR DESCRIPTION
## Summary
- Add computed `response_base64` and `sensitive_response_base64` to the `terracurl_request` data source for lossless binary response download via RFC 4648 base64 encoding.
- Encode raw response bytes (not the string-coerced body); empty responses encode to `""`, not `"{}"`.
- Warn when response bytes are not valid UTF-8 so users know to use `response_base64`.
- Add example, guide note, tests, and CHANGELOG **2.11.0**. Closes #62.

## Test plan
- [x] `golangci-lint run --config=.golangci.yml ./...`
- [x] Unit tests for base64 encoding and sensitive routing
- [x] Acceptance tests with binary httpmock payloads


Made with [Cursor](https://cursor.com)